### PR TITLE
Add HEIC Image Support with Metadata Display

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,8 @@
         "@tailwindcss/cli": "^4.0.9",
         "@tailwindcss/vite": "^4.0.9",
         "date-fns": "^4.1.0",
+        "exifr": "^7.1.3",
+        "heic2any": "^0.0.4",
         "jwt-decode": "^4.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3493,6 +3495,12 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3926,6 +3934,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,8 @@
     "@tailwindcss/cli": "^4.0.9",
     "@tailwindcss/vite": "^4.0.9",
     "date-fns": "^4.1.0",
+    "exifr": "^7.1.3",
+    "heic2any": "^0.0.4",
     "jwt-decode": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/client/src/components/ui/ImageMetadataDisplay.tsx
+++ b/client/src/components/ui/ImageMetadataDisplay.tsx
@@ -1,0 +1,157 @@
+// src/components/ui/ImageMetadataDisplay.tsx
+import React, { useState } from 'react';
+import { ImageMetadata } from '../../types';
+
+interface ImageMetadataDisplayProps {
+    metadata: ImageMetadata;
+    className?: string;
+}
+
+export const ImageMetadataDisplay: React.FC<ImageMetadataDisplayProps> = ({
+    metadata,
+    className = '',
+}) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    // Validation for metadata
+    const hasMetadata = metadata && typeof metadata === 'object' && Object.keys(metadata).length > 0;
+
+    // Format the date if it exists
+    const formatDate = (dateString: string) => {
+        try {
+            return new Date(dateString).toLocaleString();
+        } catch {
+            return dateString;
+        }
+    };
+
+    // Define only the essential metadata fields for trail issues
+    const essentialMetadataKeys = [
+        'DateTimeOriginal'
+    ];
+
+    // Filter metadata to only include essential fields
+    const filteredMetadata = Object.entries(metadata || {}).filter(([key]) =>
+        essentialMetadataKeys.includes(key));
+
+    // Get user-friendly names for metadata fields
+    const getFriendlyName = (key: string): string => {
+        const nameMap: Record<string, string> = {
+            DateTimeOriginal: 'Date Taken',
+        };
+        return nameMap[key] || key;
+    };
+
+    // Format values appropriately
+    const formatValue = (key: string, value: string | number | boolean | undefined): string => {
+        // Handle undefined values
+        if (value === undefined) {
+            return '';
+        }
+
+        if (key === 'DateTimeOriginal' && typeof value === 'string') {
+            return formatDate(value);
+        }
+        return String(value);
+    };
+
+    // Check if we have coordinates
+    const hasCoordinates = metadata?.latitude !== undefined && metadata?.longitude !== undefined;
+
+    // Get coordinates string
+    const getCoordinatesString = () => {
+        if (hasCoordinates) {
+            const lat = metadata.latitude!.toFixed(6);
+            const lon = metadata.longitude!.toFixed(6);
+            return `${lat},${lon}`;
+        }
+        return '';
+    };
+
+    // If no relevant metadata is available at all, show a message
+    if (!hasMetadata && !hasCoordinates) {
+        return null;
+    }
+
+    // If no relevant metadata is available for display but component is rendered, show message
+    if (filteredMetadata.length === 0 && !hasCoordinates) {
+        return (
+            <div className={`bg-gray-50 rounded-lg p-3 text-sm ${className}`}>
+                <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-500">No image metadata available</span>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={`rounded-lg overflow-hidden transition-all duration-300 ${className}`}>
+            <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="w-full flex items-center justify-between bg-gray-50 hover:bg-gray-100 p-3 text-sm border border-gray-200 rounded-lg transition-colors cursor-pointer"
+            >
+                <div className="flex items-center">
+                    <svg className="w-4 h-4 text-gray-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <span className="font-medium text-gray-700">Image Metadata</span>
+                </div>
+                <svg
+                    className={`w-5 h-5 text-gray-500 transition-transform duration-200 ${isExpanded ? 'transform rotate-180' : ''}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+
+            {isExpanded && (
+                <div className="bg-white border border-gray-200 border-t-0 rounded-b-lg p-4 text-sm shadow-sm">
+                    <div className="space-y-3">
+                        {filteredMetadata.length > 0 ? (
+                            filteredMetadata.map(([key, value]) => (
+                                <div key={key} className="flex justify-between">
+                                    <span className="text-gray-600 font-medium">{getFriendlyName(key)}:</span>
+                                    <span className="text-gray-900 ml-4">{formatValue(key, value)}</span>
+                                </div>
+                            ))
+                        ) : (
+                            <p className="text-gray-500 italic">No detailed photo information available</p>
+                        )}
+
+                        {hasCoordinates && (
+                            <>
+                                <div className="flex justify-between">
+                                    <span className="text-gray-600 font-medium">Latitude:</span>
+                                    <span className="text-gray-900 ml-4">{metadata.latitude!.toFixed(6)}</span>
+                                </div>
+                                <div className="flex justify-between">
+                                    <span className="text-gray-600 font-medium">Longitude:</span>
+                                    <span className="text-gray-900 ml-4">{metadata.longitude!.toFixed(6)}</span>
+                                </div>
+                            </>
+                        )}
+                    </div>
+
+                    {hasCoordinates && (
+                        <div className="mt-3">
+                            <a
+                                href={`https://www.google.com/maps/search/?api=1&query=${getCoordinatesString()}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center text-blue-600 hover:text-blue-800 text-sm cursor-pointer"
+                            >
+                                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                </svg>
+                                View Location on Map
+                            </a>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/client/src/components/ui/ImageUpload.tsx
+++ b/client/src/components/ui/ImageUpload.tsx
@@ -1,30 +1,117 @@
 // src/components/ui/ImageUpload.tsx
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import heic2any from 'heic2any';
+import exifr from 'exifr';
+import { ImageMetadata } from '../../types';
 
 interface ImageUploadProps {
     label?: string;
-    onChange: (file: File | null, previewUrl: string | null) => void;
+    onChange: (file: File | null, previewUrl: string | null, metadata?: ImageMetadata) => void;
     existingImageUrl?: string;
+    existingMetadata?: ImageMetadata;
     error?: string;
     className?: string;
+    acceptedFormats?: string;
 }
 
 export const ImageUpload: React.FC<ImageUploadProps> = ({
     label = 'Upload Image',
     onChange,
     existingImageUrl,
+    existingMetadata,
     error,
-    className = ''
+    className = '',
+    acceptedFormats = 'image/jpeg,image/png,image/gif,image/heic,image/heif'
 }) => {
     const [preview, setPreview] = useState<string | null>(existingImageUrl || null);
     const [isDragging, setIsDragging] = useState(false);
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [/* metadata - unused but kept for future use */, setMetadata] = useState<ImageMetadata | undefined>(existingMetadata);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const processFile = async (file: File) => {
+        setIsProcessing(true);
+        try {
+            let processedFile = file;
+            let extractedMetadata: ImageMetadata = {};
+
+            // Try to extract metadata from original file first (before any conversion)
+            try {
+                // Specify the return type of exifr.parse
+                const originalMetadata = await exifr.parse(file, {
+                    gps: true,
+                    tiff: true,
+                    exif: true,
+                    translateKeys: true,
+                    translateValues: true,
+                    reviveValues: true
+                }) as ImageMetadata;
+
+                if (originalMetadata) {
+                    // Keep original GPS coordinates as they are
+                    extractedMetadata = originalMetadata;
+                }
+            } catch (metadataError) {
+                // eslint-disable-next-line no-console
+                console.error('Error extracting initial metadata:', metadataError);
+            }
+
+            // Handle HEIC/HEIF conversion
+            if (file.type === 'image/heic' || file.type === 'image/heif' ||
+                file.name.toLowerCase().endsWith('.heic') || file.name.toLowerCase().endsWith('.heif')) {
+                try {
+                    // Convert HEIC to JPEG Blob
+                    const convertedBlob = await heic2any({
+                        blob: file,
+                        toType: 'image/jpeg',
+                        quality: 0.8
+                    }) as Blob;
+
+                    // Create a new File from the converted Blob
+                    processedFile = new File(
+                        [convertedBlob],
+                        file.name.replace(/\.(heic|heif)$/i, '.jpg'),
+                        { type: 'image/jpeg' }
+                    );
+
+                    // If no metadata was extracted from original, try from converted
+                    if (Object.keys(extractedMetadata).length === 0) {
+                        try {
+                            const convertedMetadata = await exifr.parse(processedFile) as ImageMetadata;
+
+                            if (convertedMetadata) {
+                                // Keep the original metadata as is
+                                extractedMetadata = convertedMetadata;
+                            }
+                        } catch (err) {
+                            // eslint-disable-next-line no-console
+                            console.error('Error extracting metadata from converted file:', err);
+                        }
+                    }
+                } catch (conversionError) {
+                    // eslint-disable-next-line no-console
+                    console.error('Error converting HEIC/HEIF image:', conversionError);
+                }
+            }
+
+            // Create preview URL
+            const filePreview = URL.createObjectURL(processedFile);
+            setPreview(filePreview);
+            setMetadata(extractedMetadata);
+
+            onChange(processedFile, filePreview, extractedMetadata);
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Error processing image:', error);
+        } finally {
+            setIsProcessing(false);
+        }
+    };
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0] || null;
         if (file) {
-            const filePreview = URL.createObjectURL(file);
-            setPreview(filePreview);
-            onChange(file, filePreview);
+            processFile(file);
         }
     };
 
@@ -41,18 +128,22 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
     const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
         e.preventDefault();
         setIsDragging(false);
-        
+
         if (e.dataTransfer.files && e.dataTransfer.files[0]) {
             const file = e.dataTransfer.files[0];
-            const filePreview = URL.createObjectURL(file);
-            setPreview(filePreview);
-            onChange(file, filePreview);
+            processFile(file);
         }
     };
 
     const removeImage = () => {
         setPreview(null);
-        onChange(null, null);
+        setMetadata(undefined);
+        onChange(null, null, undefined);
+
+        // Reset the file input
+        if (inputRef.current) {
+            inputRef.current.value = '';
+        }
     };
 
     return (
@@ -62,17 +153,26 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
                     {label}
                 </label>
             )}
-            
-            <div 
+
+            <div
                 className={`mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-dashed rounded-md 
-                    ${isDragging ? 'border-blue-400 bg-blue-50' : 'border-gray-300'}
-                    ${error ? 'border-red-300' : ''}
-                    transition-colors cursor-pointer`}
+            ${isDragging ? 'border-blue-400 bg-blue-50' : 'border-gray-300'}
+            ${error ? 'border-red-300' : ''}
+            ${isProcessing ? 'opacity-70' : ''}
+            transition-colors cursor-pointer`}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
             >
-                {!preview ? (
+                {isProcessing ? (
+                    <div className="text-center">
+                        <svg className="animate-spin h-8 w-8 text-blue-500 mx-auto" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        <p className="mt-2 text-sm text-gray-600">Processing image...</p>
+                    </div>
+                ) : !preview ? (
                     <div className="space-y-1 text-center">
                         <svg
                             className="mx-auto h-12 w-12 text-gray-400"
@@ -98,13 +198,14 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
                                     name="file-upload"
                                     type="file"
                                     className="sr-only"
-                                    accept="image/*"
+                                    accept={acceptedFormats}
                                     onChange={handleFileChange}
+                                    ref={inputRef}
                                 />
                             </label>
                             <p className="pl-1">or drag and drop</p>
                         </div>
-                        <p className="text-xs text-gray-500">PNG, JPG, GIF up to 10MB</p>
+                        <p className="text-xs text-gray-500">PNG, JPG, GIF, HEIC up to 10MB</p>
                     </div>
                 ) : (
                     <div className="relative w-full">
@@ -116,7 +217,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
                         <button
                             type="button"
                             onClick={removeImage}
-                            className="absolute -top-3 -right-3 rounded-full bg-red-500 p-1 text-white hover:bg-red-600 focus:outline-none"
+                            className="absolute -top-3 -right-3 rounded-full bg-red-500 p-1 text-white hover:bg-red-600 focus:outline-none hover:cursor-pointer"
                         >
                             <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -126,6 +227,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
                     </div>
                 )}
             </div>
+
             {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
         </div>
     );

--- a/client/src/pages/issues/IssueDetailPage.tsx
+++ b/client/src/pages/issues/IssueDetailPage.tsx
@@ -17,6 +17,7 @@ import { mockApi } from '../../services/mockData';
 import { format } from 'date-fns';
 import Location from '../../components/ui/Location';
 import { IssueTimer } from '../../components/issues/IssueTimer';
+import { ImageMetadataDisplay } from '../../components/ui/ImageMetadataDisplay';
 
 export const IssueDetailPage: React.FC = () => {
     const { issueId } = useParams<{ issueId: string }>();
@@ -180,9 +181,17 @@ export const IssueDetailPage: React.FC = () => {
                                 <img
                                     src={issue.issue_image}
                                     alt="Issue"
-                                    className="w-full h-auto max-h-96 object-cover"
+                                    className="w-full h-auto max-h-96 object-contain"
                                 />
                             </div>
+
+                            {/* Only render the metadata component if there's metadata available */}
+                            {issue.imageMetadata && (
+                                <ImageMetadataDisplay
+                                    metadata={issue.imageMetadata}
+                                    className="mt-3"
+                                />
+                            )}
                         </div>
                     )}
 

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -16,6 +16,23 @@ export type Trail = {
 
 export type IssueStatus = 'open' | 'in_progress' | 'resolved';
 
+export interface ImageMetadata {
+    DateTimeOriginal?: string;
+    Make?: string;
+    Model?: string;
+    latitude?: number;
+    longitude?: number;
+    Orientation?: number;
+    ExposureTime?: number;
+    FNumber?: number;
+    ISO?: number;
+    LensModel?: string;
+    Software?: string;
+    GPSLatitude?: number;
+    GPSLongitude?: number;
+    [key: string]: string | number | boolean | undefined; // For any other properties
+}
+
 export type Issue = {
     issue_id: number;
     park_id: number;
@@ -28,6 +45,7 @@ export type Issue = {
     issue_type: string;
     urgency: number; // 1-5 scale
     issue_image?: string;
+    imageMetadata?: ImageMetadata;
     lon?: number;
     lat?: number;
     notify_reporter: boolean;
@@ -62,4 +80,5 @@ export type IssueResolutionUpdate = {
     resolve_notes?: string;
     resolved_at: string;
     resolved_by: number; // user_id
+    resolve_imageMetadata?: ImageMetadata;
 };


### PR DESCRIPTION
## Overview
This pull request adds support for uploading HEIC image formats (commonly used by iPhones). The implementation includes automatic conversion to JPEG format and preservation of important EXIF metadata, including date and GPS coordinates. The extracted metadata is displayed in issue detail views.

Resolves #48 

## Changes
- Added HEIC to accepted formats
- Implemented conversion from HEIC to JPEG using the heic2any library
- Enhanced metadata extraction with the exifr library
- Added direct link to Google Maps when GPS coordinates are available

## Screenshots
<img width="780" alt="截屏2025-03-28 上午12 19 41" src="https://github.com/user-attachments/assets/72fd1fea-4374-44a3-8131-b6c8ad6ef661" />
<img width="780" alt="截屏2025-03-28 上午12 19 49" src="https://github.com/user-attachments/assets/ae1bb99b-adf1-4200-9a90-466e0e44591f" />

<img width="780" alt="截屏2025-03-28 上午12 18 34" src="https://github.com/user-attachments/assets/60bc8c26-fc51-417e-a26f-bda0fba2bcb7" />

