### PR TITLE
GPS selector broken fix 

### DIFF
--- a/client/src/components/ui/Location.tsx
+++ b/client/src/components/ui/Location.tsx
@@ -58,10 +58,10 @@ const Location: React.FC<LocationProps> = ({
         if (!readOnly) {
             marker.current.on('dragend', (e: LeafletMarkerDragEvent) => {
                 const newPos = e.target.getLatLng();
-                setLat(newPos.latitude);
+                setLat(newPos.lat);
                 setLon(newPos.lng);
                 if (onLocationSelected) {
-                    onLocationSelected(newPos.latitude, newPos.lng);
+                    onLocationSelected(newPos.lat, newPos.lng);
                 }
             });
         }
@@ -105,7 +105,7 @@ const Location: React.FC<LocationProps> = ({
         // Click handler for the map (only if not readOnly)
         if (!readOnly) {
             leafletMap.current.on('click', (e: LeafletMouseEvent) => {
-                const { latitude: newLat, lng: newLon } = e.latlng;
+                const { lat: newLat, lng: newLon } = e.latlng;
                 updateMarker(newLat, newLon);
                 setLat(newLat);
                 setLon(newLon);

--- a/client/src/types/leaflet.ts
+++ b/client/src/types/leaflet.ts
@@ -7,12 +7,12 @@ export interface LeafletMap {
 }
 
 export interface LeafletMouseEvent {
-    latlng: { latitude: number; lng: number };
+    latlng: { lat: number; lng: number };
 }
 
 export interface LeafletMarkerDragEvent {
     target: {
-        getLatLng: () => { latitude: number; lng: number };
+        getLatLng: () => { lat: number; lng: number };
     };
 }
 


### PR DESCRIPTION
## Description
This PR fixes issue where dragging the map marker in the Location would cause unexpected error of broken map. The problem was caused by a mismatch between custom type definitions and the actual Leaflet api.

## Changes
1. Updated LeafletMouseEvent and LeafletMarkerDragEvent interfaces to use **lat** instead of latitude to match api.
2. Fixed both map click and marker drag handlers to use the correct property names.

## Issue
Resolves #101 
