### PR TITLE
Use env variables for checking permissions

### DIFF
--- a/client/src/providers/AuthProvider.tsx
+++ b/client/src/providers/AuthProvider.tsx
@@ -85,7 +85,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     };
 
     const isAuthenticated = !!user;
-    const hasPermission = user?.email?.endsWith('@trailpittsburgh.org') ?? false;
+    const hasPermission = user?.email?.endsWith(`@${import.meta.env.VITE_ORGANIZATION_DOMAIN}`) ?? false;
 
     return (
         <AuthContext.Provider value={{ user, loading, login, logout, isAuthenticated, hasPermission }}>


### PR DESCRIPTION
This PR fixes authentication problem on client side. Allows for authorized org domain to be set as ENV variable.