### PR TITLE
Fix header error in ParkController.getPark

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,9 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
-    "testMatch": ["**/test/**/*.test.ts"],
+    "testMatch": [
+      "**/test/**/*.test.ts"
+    ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1"
     },

--- a/server/src/controllers/ParkController.ts
+++ b/server/src/controllers/ParkController.ts
@@ -25,6 +25,7 @@ export class ParkController {
 
             if (!park) {
                 res.status(404).json({ message: 'Park not found.' });
+                return;
             }
 
             res.status(200).json({ park });


### PR DESCRIPTION
## Description
This PR fixes a bug in the `getPark` method of `ParkController.ts` where a missing return statement caused Express to attempt sending multiple responses for a single request.

## Problem
When a park is not found, the method was sending a 404 response but continuing execution, which led to attempting to send a 200 response as well. This caused the error: "Cannot set headers after they are sent to the client".

## Solution
Added a `return` statement after sending the 404 response to prevent further execution.

## Testing
- All tests in `parkRoutes.test.ts` now pass

## Related Issues
Fixes #119 