### PR TITLE
User Test 1 Feedback Implementation

### DIFF
--- a/client/src/components/issues/IssueReportForm.tsx
+++ b/client/src/components/issues/IssueReportForm.tsx
@@ -23,7 +23,7 @@ interface IssueReportFormProps {
 export const IssueReportForm: React.FC<IssueReportFormProps> = ({ onSubmit }) => {
     const [formData, setFormData] = useState<Partial<IssueParams>>({
         isPublic: true,
-        status: IssueStatusEnum.OPEN,
+        status: IssueStatusEnum.UNRESOLVED,
         description: '',
         issueType: IssueTypeEnum.OBSTRUCTION,
         safetyRisk: IssueRiskEnum.NO_RISK,
@@ -270,7 +270,7 @@ export const IssueReportForm: React.FC<IssueReportFormProps> = ({ onSubmit }) =>
             // Reset form
             setFormData({
                 isPublic: true,
-                status: IssueStatusEnum.OPEN,
+                status: IssueStatusEnum.UNRESOLVED,
                 // description: '',
                 issueType: IssueTypeEnum.OTHER,
                 safetyRisk: IssueRiskEnum.NO_RISK,

--- a/client/src/components/issues/IssueReportForm.tsx
+++ b/client/src/components/issues/IssueReportForm.tsx
@@ -4,7 +4,10 @@ import React, { useState, useEffect } from 'react';
 import {
     Park, ImageMetadata, IssueParams, IssueStatusEnum, IssueTypeEnum, IssueRiskEnum
 } from '../../types';
-import { getSafetyRiskLabel } from '../../utils/issueSafetyRiskUtils';
+import {
+    getSafetyRiskDescription,
+    getSafetyRiskLabel,
+} from '../../utils/issueSafetyRiskUtils';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { Alert } from '../ui/Alert';
@@ -53,6 +56,11 @@ export const IssueReportForm: React.FC<IssueReportFormProps> = ({ onSubmit }) =>
         { value: IssueTypeEnum.OBSTRUCTION, label: 'Obstruction (tree down, etc.)' },
         { value: IssueTypeEnum.WATER, label: 'Standing Water/Mud' },
         { value: IssueTypeEnum.OTHER, label: 'Other' }
+    ];
+    const safetyRiskLevels = [
+        IssueRiskEnum.NO_RISK,
+        IssueRiskEnum.MINOR_RISK,
+        IssueRiskEnum.SERIOUS_RISK,
     ];
 
     useEffect(() => {
@@ -519,15 +527,14 @@ export const IssueReportForm: React.FC<IssueReportFormProps> = ({ onSubmit }) =>
                         <label className="block text-sm font-medium text-gray-700 mb-3">
                             Safety Risk?
                         </label>
-                        {/* For large screens: all options in one row */}
-                        <div className="hidden md:grid md:grid-cols-3 gap-3">
-                            {Object.values(IssueRiskEnum).map((level) => (
+                        <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+                            {safetyRiskLevels.map((level) => (
                                 <button
                                     key={level}
                                     type="button"
                                     onClick={() => handleSafetyRiskSelect(level)}
                                     className={`
-                                        flex items-center p-4 rounded-lg border transition-all hover:bg-gray-50 cursor-pointer
+                                        rounded-lg border p-4 text-left transition-all hover:bg-gray-50 cursor-pointer
                                         ${formData.safetyRisk === level
                                     ? 'border-blue-600 bg-blue-50'
                                     : 'border-gray-200'
@@ -535,26 +542,7 @@ export const IssueReportForm: React.FC<IssueReportFormProps> = ({ onSubmit }) =>
                                     `}
                                 >
                                     <div className="text-sm font-medium">{getSafetyRiskLabel(level)}</div>
-                                </button>
-                            ))}
-                        </div>
-
-                        {/* For mobile: options stacked one per row */}
-                        <div className="grid grid-cols-1 gap-3 md:hidden">
-                            {Object.values(IssueRiskEnum).map((level) => (
-                                <button
-                                    key={level}
-                                    type="button"
-                                    onClick={() => handleSafetyRiskSelect(level)}
-                                    className={`
-                                        flex items-center p-4 rounded-lg border transition-all hover:bg-gray-50 cursor-pointer
-                                        ${formData.safetyRisk === level
-                                    ? 'border-blue-600 bg-blue-50'
-                                    : 'border-gray-200'
-                                }
-                                    `}
-                                >
-                                    <div className="text-sm font-medium">{getSafetyRiskLabel(level)}</div>
+                                    <p className="mt-1 text-xs text-gray-600">{getSafetyRiskDescription(level)}</p>
                                 </button>
                             ))}
                         </div>

--- a/client/src/components/issues/IssueStatusBadge.tsx
+++ b/client/src/components/issues/IssueStatusBadge.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { IssueStatusEnum } from '../../types';
 import { Badge } from '../ui/Badge';
+import { getIssueStatusLabel, getIssueStatusTooltip } from '../../utils/issueStatusUtils';
 
 interface IssueStatusBadgeProps {
     status: IssueStatusEnum;
@@ -15,15 +16,13 @@ export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = ({ status, clas
         [IssueStatusEnum.RESOLVED]: 'success'
     } as const;
 
-    const statusLabel = {
-        [IssueStatusEnum.UNRESOLVED]: 'Unresolved',
-        [IssueStatusEnum.IN_PROGRESS]: 'In Progress',
-        [IssueStatusEnum.RESOLVED]: 'Resolved'
-    };
-
     return (
-        <Badge variant={statusVariant[status]} className={className}>
-            {statusLabel[status]}
+        <Badge
+            variant={statusVariant[status]}
+            className={className}
+            title={getIssueStatusTooltip(status)}
+        >
+            {getIssueStatusLabel(status)}
         </Badge>
     );
 };

--- a/client/src/components/issues/IssueStatusBadge.tsx
+++ b/client/src/components/issues/IssueStatusBadge.tsx
@@ -10,9 +10,9 @@ interface IssueStatusBadgeProps {
 
 export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = ({ status, className = '' }) => {
     const statusVariant = {
-        [IssueStatusEnum.UNRESOLVED]: 'success',
+        [IssueStatusEnum.UNRESOLVED]: 'danger',
         [IssueStatusEnum.IN_PROGRESS]: 'warning',
-        [IssueStatusEnum.RESOLVED]: 'secondary'
+        [IssueStatusEnum.RESOLVED]: 'success'
     } as const;
 
     const statusLabel = {

--- a/client/src/components/issues/IssueStatusBadge.tsx
+++ b/client/src/components/issues/IssueStatusBadge.tsx
@@ -10,13 +10,13 @@ interface IssueStatusBadgeProps {
 
 export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = ({ status, className = '' }) => {
     const statusVariant = {
-        [IssueStatusEnum.OPEN]: 'success',
+        [IssueStatusEnum.UNRESOLVED]: 'success',
         [IssueStatusEnum.IN_PROGRESS]: 'warning',
         [IssueStatusEnum.RESOLVED]: 'secondary'
     } as const;
 
     const statusLabel = {
-        [IssueStatusEnum.OPEN]: 'Open',
+        [IssueStatusEnum.UNRESOLVED]: 'Open',
         [IssueStatusEnum.IN_PROGRESS]: 'In Progress',
         [IssueStatusEnum.RESOLVED]: 'Resolved'
     };

--- a/client/src/components/issues/IssueStatusBadge.tsx
+++ b/client/src/components/issues/IssueStatusBadge.tsx
@@ -16,7 +16,7 @@ export const IssueStatusBadge: React.FC<IssueStatusBadgeProps> = ({ status, clas
     } as const;
 
     const statusLabel = {
-        [IssueStatusEnum.UNRESOLVED]: 'Open',
+        [IssueStatusEnum.UNRESOLVED]: 'Unresolved',
         [IssueStatusEnum.IN_PROGRESS]: 'In Progress',
         [IssueStatusEnum.RESOLVED]: 'Resolved'
     };

--- a/client/src/components/parks/ParkCard.tsx
+++ b/client/src/components/parks/ParkCard.tsx
@@ -26,14 +26,14 @@ export const ParkCard: React.FC<ParkCardProps> = ({ park, allIssues }) => {
                 className="h-full transition-shadow hover:shadow-lg"
                 footer={!isError && (
 
-                    <div className="flex justify-between text-sm">
-                        <span className="text-red-600 font-medium">
+                    <div className="flex justify-between text-sm gap-2">
+                        <span className="rounded-md bg-red-100 px-2 py-1 text-red-700 font-medium">
                             Unresolved: {unresolvedIssuesCount}
                         </span>
-                        <span className="text-yellow-600 font-medium">
+                        <span className="rounded-md bg-yellow-100 px-2 py-1 text-yellow-800 font-medium">
                             In Progress: {inprocessIssuesCount}
                         </span>
-                        <span className="text-green-600 font-medium">
+                        <span className="rounded-md bg-green-100 px-2 py-1 text-green-800 font-medium">
                             Resolved: {resolvedIssuesCount}
                         </span>
                     </div>
@@ -41,18 +41,18 @@ export const ParkCard: React.FC<ParkCardProps> = ({ park, allIssues }) => {
             >
                 <div className="flex items-center justify-between mb-4">
                     <h3 className="text-lg font-semibold text-gray-900">{park.name}</h3>
-                    {park.isActive ? (
-                        <Badge variant="success">Active</Badge>
-                    ) : (
-                        <Badge variant="secondary">Inactive</Badge>
-                    )}
+                    <div className="flex items-center gap-2">
+                        {!park.isActive && (
+                            <Badge variant="secondary">Inactive</Badge>
+                        )}
+                        <span className="text-sm text-blue-600 font-medium">
+                            View details &rarr;
+                        </span>
+                    </div>
                 </div>
                 <p className="text-sm text-gray-500 mb-4">
-                    <span className="font-medium">County:</span> {park.county}
+                    {park.county} County
                 </p>
-                <div className="text-sm text-blue-600 font-medium">
-                    View details &rarr;
-                </div>
             </Card>
         </Link>
     );

--- a/client/src/components/parks/ParkCard.tsx
+++ b/client/src/components/parks/ParkCard.tsx
@@ -16,7 +16,7 @@ export const ParkCard: React.FC<ParkCardProps> = ({ park, allIssues }) => {
     const isError = !allIssues;
     
     // Default counts to 0 if there's an error/no issues
-    const openIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
+    const unresolvedIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
     const inprocessIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.IN_PROGRESS).length;
     const resolvedIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.RESOLVED).length;
 
@@ -28,7 +28,7 @@ export const ParkCard: React.FC<ParkCardProps> = ({ park, allIssues }) => {
 
                     <div className="flex justify-between text-sm">
                         <span className="text-red-600 font-medium">
-                            Open: {openIssuesCount}
+                            Unresolved: {unresolvedIssuesCount}
                         </span>
                         <span className="text-yellow-600 font-medium">
                             In Progress: {inprocessIssuesCount}

--- a/client/src/components/parks/ParkCard.tsx
+++ b/client/src/components/parks/ParkCard.tsx
@@ -16,7 +16,7 @@ export const ParkCard: React.FC<ParkCardProps> = ({ park, allIssues }) => {
     const isError = !allIssues;
     
     // Default counts to 0 if there's an error/no issues
-    const openIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.OPEN).length;
+    const openIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
     const inprocessIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.IN_PROGRESS).length;
     const resolvedIssuesCount = isError ? 0 : allIssues.filter((issue) => issue.status === IssueStatusEnum.RESOLVED).length;
 

--- a/client/src/components/ui/Badge.tsx
+++ b/client/src/components/ui/Badge.tsx
@@ -7,12 +7,14 @@ interface BadgeProps {
     variant?: BadgeVariant;
     children: React.ReactNode;
     className?: string;
+    title?: string;
 }
 
 export const Badge: React.FC<BadgeProps> = ({
     variant = 'primary',
     children,
-    className = ''
+    className = '',
+    title
 }) => {
     const variantClasses = {
         primary: 'bg-blue-100 text-blue-800',
@@ -24,7 +26,10 @@ export const Badge: React.FC<BadgeProps> = ({
     };
     
     return (
-        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${variantClasses[variant]} ${className}`}>
+        <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${variantClasses[variant]} ${className}`}
+            title={title}
+        >
             {children}
         </span>
     );

--- a/client/src/pages/auth/ProfilePage.tsx
+++ b/client/src/pages/auth/ProfilePage.tsx
@@ -21,8 +21,8 @@ export const ProfilePage: React.FC = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [issues, setIssues] = useState<Issue[]>([]);
     const statusColors: Record<IssueStatusEnum, string> = {
-        UNRESOLVED: 'bg-yellow-100 text-yellow-800',
-        IN_PROGRESS: 'bg-blue-100 text-blue-800',
+        UNRESOLVED: 'bg-red-100 text-red-700',
+        IN_PROGRESS: 'bg-yellow-100 text-yellow-800',
         RESOLVED: 'bg-green-100 text-green-800',
     };
 

--- a/client/src/pages/auth/ProfilePage.tsx
+++ b/client/src/pages/auth/ProfilePage.tsx
@@ -14,6 +14,7 @@ import { formatUserRole, hasAccess } from '../../utils/formatters';
 import { LoadingSpinner } from '../../components/layout/LoadingSpinner';
 import { issueApi } from '../../services/api';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
+import { getIssueStatusLabel, getIssueStatusTooltip } from '../../utils/issueStatusUtils';
 
 export const ProfilePage: React.FC = () => {
     const location = useLocation();
@@ -136,8 +137,9 @@ export const ProfilePage: React.FC = () => {
                                         {/* Status Badge */}
                                         <span
                                             className={`px-2 py-1 text-xs font-semibold rounded ${statusColors[issue.status]}`}
+                                            title={getIssueStatusTooltip(issue.status)}
                                         >
-                                            {issue.status.replace('_', ' ')}
+                                            {getIssueStatusLabel(issue.status)}
                                         </span>
 
                                         {/* Issue Type / Title */}

--- a/client/src/pages/auth/ProfilePage.tsx
+++ b/client/src/pages/auth/ProfilePage.tsx
@@ -21,7 +21,7 @@ export const ProfilePage: React.FC = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [issues, setIssues] = useState<Issue[]>([]);
     const statusColors: Record<IssueStatusEnum, string> = {
-        OPEN: 'bg-yellow-100 text-yellow-800',
+        UNRESOLVED: 'bg-yellow-100 text-yellow-800',
         IN_PROGRESS: 'bg-blue-100 text-blue-800',
         RESOLVED: 'bg-green-100 text-green-800',
     };

--- a/client/src/pages/home/HomePage.tsx
+++ b/client/src/pages/home/HomePage.tsx
@@ -26,9 +26,9 @@ export const HomePage: React.FC = () => {
                                         Report an Issue
                                     </Button>
                                 </Link>
-                                <Link to="/parks">
+                                <Link to="/issues">
                                     <Button variant="secondary" size="lg" className="transition-all hover:-translate-y-0.5">
-                                        View Parks
+                                        View Issues
                                     </Button>
                                 </Link>
                             </div>

--- a/client/src/pages/issues/IssueDetailCard.tsx
+++ b/client/src/pages/issues/IssueDetailCard.tsx
@@ -12,7 +12,11 @@ import { LoadingSpinner } from '../../components/layout/LoadingSpinner';
 import { ImageMetadataDisplay } from '../../components/ui/ImageMetadataDisplay';
 import { issueApi, parkApi } from '../../services/api';
 import { issueTypeFrontendToEnum } from '../../utils/issueTypeUtils';
-import { getIssueStatusColor } from '../../utils/issueStatusUtils';
+import {
+    getIssueStatusColor,
+    getIssueStatusLabel,
+    getIssueStatusTooltip,
+} from '../../utils/issueStatusUtils';
 import { Button } from '../../components/ui/Button';
 import { useAuth } from '../../providers/AuthProvider';
 import { iconForType } from './issuePinIcons';
@@ -595,7 +599,9 @@ export const IssueDetailCard: React.FC<{
                                                         'inline-flex mt-1 items-center rounded-full px-2 py-0.5 text-xs font-semibold',
                                                         getIssueStatusColor(issue.status),
                                                     ].join(' ')}>
-                                                        {issue.status.replace('_', ' ')}
+                                                        <span title={getIssueStatusTooltip(issue.status)}>
+                                                            {getIssueStatusLabel(issue.status)}
+                                                        </span>
                                                     </span>
                                                 </div>
 

--- a/client/src/pages/issues/IssueDetailCard.tsx
+++ b/client/src/pages/issues/IssueDetailCard.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
-    Issue, IssueStatusEnum, IssueTypeEnum, Park, UserRoleEnum
+    Issue, IssueRiskEnum, IssueStatusEnum, IssueTypeEnum, Park, UserRoleEnum
 } from '../../types';
 import {
     LeafletMap, LeafletMarker, LeafletMarkerDragEvent
@@ -17,6 +17,10 @@ import {
     getIssueStatusLabel,
     getIssueStatusTooltip,
 } from '../../utils/issueStatusUtils';
+import {
+    getSafetyRiskLabel,
+    getStewardSafetyRiskDescription,
+} from '../../utils/issueSafetyRiskUtils';
 import { Button } from '../../components/ui/Button';
 import { useAuth } from '../../providers/AuthProvider';
 import { iconForType } from './issuePinIcons';
@@ -36,6 +40,7 @@ export const IssueDetailCard: React.FC<{
     const [isEditing, setIsEditing] = useState(false);
     const [editedDescription, setEditedDescription] = useState('');
     const [editedIssueType, setEditedIssueType] = useState('');
+    const [editedSafetyRisk, setEditedSafetyRisk] = useState<IssueRiskEnum>(IssueRiskEnum.NO_RISK);
     const [editedParkId, setEditedParkId] = useState<number>(0);
     const [editedLatitude, setEditedLatitude] = useState<number | null>(null);
     const [editedLongitude, setEditedLongitude] = useState<number | null>(null);
@@ -137,6 +142,7 @@ export const IssueDetailCard: React.FC<{
 
             const updateData: {
                 description?: string;
+                safetyRisk?: IssueRiskEnum;
                 issueType?: IssueTypeEnum;
                 parkId?: number;
                 latitude?: number;
@@ -150,6 +156,10 @@ export const IssueDetailCard: React.FC<{
             const editedIssueTypeEnum = issueTypeFrontendToEnum(editedIssueType);
             if (editedIssueTypeEnum !== issue.issueType) {
                 updateData.issueType = editedIssueTypeEnum;
+            }
+
+            if (editedSafetyRisk !== issue.safetyRisk) {
+                updateData.safetyRisk = editedSafetyRisk;
             }
 
             if (editedParkId !== issue.parkId) {
@@ -374,6 +384,7 @@ export const IssueDetailCard: React.FC<{
     const initializeEditedFields = (sourceIssue: Issue) => {
         setEditedDescription(sourceIssue.description ?? '');
         setEditedIssueType(sourceIssue.issueType.toLowerCase());
+        setEditedSafetyRisk(sourceIssue.safetyRisk);
         setEditedParkId(sourceIssue.parkId);
         setEditedLatitude(sourceIssue.latitude ?? null);
         setEditedLongitude(sourceIssue.longitude ?? null);
@@ -428,6 +439,11 @@ export const IssueDetailCard: React.FC<{
         { value: 'obstruction', label: 'Obstruction (tree down, etc.)' },
         { value: 'water', label: 'Standing Water/Mud' },
         { value: 'other', label: 'Other' },
+    ];
+    const safetyRiskLevels = [
+        IssueRiskEnum.NO_RISK,
+        IssueRiskEnum.MINOR_RISK,
+        IssueRiskEnum.SERIOUS_RISK,
     ];
     const activeParks = parks.filter((park) => park.isActive || park.parkId === editedParkId);
     const issueTypeDisplayLabel = (type: IssueTypeEnum | string) => {
@@ -643,6 +659,41 @@ export const IssueDetailCard: React.FC<{
                                                     {issue.status === IssueStatusEnum.RESOLVED && issue.resolvedAt
                                                         ? `Resolved on ${new Date(issue.resolvedAt).toLocaleString()}`
                                                         : `Reported on ${new Date(issue.createdAt).toLocaleString()}`}
+                                                </div>
+
+                                                {/* SAFETY RISK */}
+                                                <div className="max-w-md">
+                                                    <div className="text-sm font-medium text-gray-700">User-Reported Safety Risk</div>
+                                                    <p className="mt-1 text-xs text-gray-600">
+                                                        User-submitted, relative severity rating.
+                                                    </p>
+                                                    {isEditing && canManageIssueStatus ? (
+                                                        <div className="mt-2">
+                                                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                                                                {safetyRiskLevels.map((riskLevel) => (
+                                                                    <button
+                                                                        key={riskLevel}
+                                                                        type="button"
+                                                                        onClick={() => setEditedSafetyRisk(riskLevel)}
+                                                                        className={[
+                                                                            'rounded-md border p-2 text-left transition-colors cursor-pointer',
+                                                                            editedSafetyRisk === riskLevel
+                                                                                ? 'border-blue-500 bg-blue-50'
+                                                                                : 'border-gray-200 bg-white hover:bg-gray-50'
+                                                                        ].join(' ')}
+                                                                    >
+                                                                        <div className="text-xs font-semibold text-gray-900">{getSafetyRiskLabel(riskLevel)}</div>
+                                                                        <div className="mt-1 text-xs text-gray-600">{getStewardSafetyRiskDescription(riskLevel)}</div>
+                                                                    </button>
+                                                                ))}
+                                                            </div>
+                                                        </div>
+                                                    ) : (
+                                                        <div className="mt-2 rounded-md border border-gray-200 bg-gray-50 p-3">
+                                                            <div className="text-sm font-semibold text-gray-900">{getSafetyRiskLabel(issue.safetyRisk)}</div>
+                                                            <div className="mt-1 text-sm text-gray-600">{getStewardSafetyRiskDescription(issue.safetyRisk)}</div>
+                                                        </div>
+                                                    )}
                                                 </div>
 
                                                 {/* GROUP */}

--- a/client/src/pages/issues/IssueDetailCard.tsx
+++ b/client/src/pages/issues/IssueDetailCard.tsx
@@ -18,7 +18,11 @@ import {
     getIssueStatusTooltip,
 } from '../../utils/issueStatusUtils';
 import {
+    getPassabilityBadgeColor,
+    getPassabilityBadgeLabel,
     getSafetyRiskLabel,
+    getSafetyRiskBadgeColor,
+    getReportedSafetyRiskBadgeLabel,
     getStewardSafetyRiskDescription,
 } from '../../utils/issueSafetyRiskUtils';
 import { Button } from '../../components/ui/Button';
@@ -667,6 +671,20 @@ export const IssueDetailCard: React.FC<{
                                                     <p className="mt-1 text-xs text-gray-600">
                                                         User-submitted, relative severity rating.
                                                     </p>
+                                                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                                                        <span className={[
+                                                            'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold',
+                                                            getSafetyRiskBadgeColor(issue.safetyRisk)
+                                                        ].join(' ')}>
+                                                            {getReportedSafetyRiskBadgeLabel(issue.safetyRisk)}
+                                                        </span>
+                                                        <span className={[
+                                                            'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold',
+                                                            getPassabilityBadgeColor(issue.passible)
+                                                        ].join(' ')}>
+                                                            {getPassabilityBadgeLabel(issue.passible)}
+                                                        </span>
+                                                    </div>
                                                     {isEditing && canManageIssueStatus ? (
                                                         <div className="mt-2">
                                                             <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">

--- a/client/src/pages/issues/IssueDetailCard.tsx
+++ b/client/src/pages/issues/IssueDetailCard.tsx
@@ -695,7 +695,7 @@ export const IssueDetailCard: React.FC<{
                                                     </div>
                                                 )}
 
-                                                {!isEditing && issue.status === IssueStatusEnum.OPEN && (
+                                                {!isEditing && issue.status === IssueStatusEnum.UNRESOLVED && (
                                                     <div className="mt-3 flex flex-wrap items-center gap-2">
                                                         <Button
                                                             variant="success"

--- a/client/src/pages/issues/components/IssueDetailStatusActions.tsx
+++ b/client/src/pages/issues/components/IssueDetailStatusActions.tsx
@@ -34,7 +34,7 @@ export const IssueDetailStatusActions: React.FC<IssueDetailStatusActionsProps> =
                 </Button>
             )}
 
-            {canManageIssueStatus && !isEditing && (issueStatus === IssueStatusEnum.OPEN || issueStatus === IssueStatusEnum.RESOLVED) && (
+            {canManageIssueStatus && !isEditing && (issueStatus === IssueStatusEnum.UNRESOLVED || issueStatus === IssueStatusEnum.RESOLVED) && (
                 <Button
                     variant={issueStatus === IssueStatusEnum.RESOLVED ? 'secondary' : 'primary'}
                     size="md"

--- a/client/src/pages/issues/issuePinIcons.ts
+++ b/client/src/pages/issues/issuePinIcons.ts
@@ -2,7 +2,6 @@ import { IssueTypeEnum } from '../../types';
 import obstuctionPin from '../../assets/obstructionPin.png';
 import waterPin from '../../assets/waterPin.png';
 import otherPin from '../../assets/otherPin.png';
-import currentLocation from '../../assets/currentLocation.png';
 
 const makePinIcon = (url: string) =>
     window.L.icon({
@@ -13,9 +12,16 @@ const makePinIcon = (url: string) =>
     });
 
 export const iconForCurrentLocation = () => {
-    return window.L.icon({
-        iconUrl: currentLocation,
-        iconSize: [60, 60],
+    return window.L.divIcon({
+        className: 'current-location-marker',
+        html: `
+            <div style="position: relative; width: 28px; height: 28px;">
+                <span style="position: absolute; inset: 0; border-radius: 9999px; background: rgba(59, 130, 246, 0.3);"></span>
+                <span style="position: absolute; top: 50%; left: 50%; width: 12px; height: 12px; transform: translate(-50%, -50%); border-radius: 9999px; background: #3b82f6; border: 2px solid #ffffff; box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.55);"></span>
+            </div>
+        `,
+        iconSize: [28, 28],
+        iconAnchor: [14, 14],
     });
 };
 

--- a/client/src/pages/parks/ParkDetailPage.tsx
+++ b/client/src/pages/parks/ParkDetailPage.tsx
@@ -87,7 +87,7 @@ export const ParkDetailPage: React.FC = () => {
     }
 
     // Count open issues
-    const openIssuesCount = issues.filter((issue) => issue.status === IssueStatusEnum.OPEN).length;
+    const openIssuesCount = issues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
 
     return (
         <div>

--- a/client/src/pages/parks/ParkDetailPage.tsx
+++ b/client/src/pages/parks/ParkDetailPage.tsx
@@ -136,7 +136,7 @@ export const ParkDetailPage: React.FC = () => {
                     <div className="space-y-4">
                         <div>
                             <p className="text-sm font-medium text-gray-500">Unresolved Issues</p>
-                            <p className="mt-1 text-2xl font-semibold text-yellow-600">{unresolvedIssuesCount}</p>
+                            <p className="mt-1 text-2xl font-semibold text-red-600">{unresolvedIssuesCount}</p>
                         </div>
                     </div>
                 </Card>

--- a/client/src/pages/parks/ParkDetailPage.tsx
+++ b/client/src/pages/parks/ParkDetailPage.tsx
@@ -50,7 +50,7 @@ export const ParkDetailPage: React.FC = () => {
                 
                 // Fetch issues for this park
                 const issuesData = await issueApi.getIssuesByPark(id);
-                // Filter to only show public issues or open issues
+                // Filter to only show public issues or unresolved issues
                 const filteredIssues = issuesData.filter((issue) => issue.isPublic);
                 setIssues(filteredIssues);
             } catch (err) {
@@ -86,8 +86,8 @@ export const ParkDetailPage: React.FC = () => {
         );
     }
 
-    // Count open issues
-    const openIssuesCount = issues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
+    // Count unresolved issues
+    const unresolvedIssuesCount = issues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
 
     return (
         <div>
@@ -135,8 +135,8 @@ export const ParkDetailPage: React.FC = () => {
                     <h3 className="text-xl font-bold text-gray-900 mb-4">Quick Stats</h3>
                     <div className="space-y-4">
                         <div>
-                            <p className="text-sm font-medium text-gray-500">Open Issues</p>
-                            <p className="mt-1 text-2xl font-semibold text-yellow-600">{openIssuesCount}</p>
+                            <p className="text-sm font-medium text-gray-500">Unresolved Issues</p>
+                            <p className="mt-1 text-2xl font-semibold text-yellow-600">{unresolvedIssuesCount}</p>
                         </div>
                     </div>
                 </Card>

--- a/client/src/pages/parks/ParkListPage.tsx
+++ b/client/src/pages/parks/ParkListPage.tsx
@@ -13,6 +13,8 @@ import { parkApi, issueApi } from '../../services/api';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import { getIssueStatusDotColor } from '../../utils/issueStatusUtils';
 import {
+    getPassabilityBadgeColor,
+    getPassabilityBadgeLabel,
     getSafetyRiskBadgeColor,
     getReportedSafetyRiskBadgeLabel,
     getSafetyRiskLevelIndex
@@ -205,6 +207,12 @@ export const ParkListPage: React.FC = () => {
                                                             getSafetyRiskBadgeColor(issue.safetyRisk)
                                                         ].join(' ')}>
                                                             {getReportedSafetyRiskBadgeLabel(issue.safetyRisk)}
+                                                        </span>
+                                                        <span className={[
+                                                            'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold',
+                                                            getPassabilityBadgeColor(issue.passible)
+                                                        ].join(' ')}>
+                                                            {getPassabilityBadgeLabel(issue.passible)}
                                                         </span>
                                                         <span className="text-sm text-gray-500">
                                                             {formatDistanceToNow(new Date(issue.createdAt), { addSuffix: true })}

--- a/client/src/pages/parks/ParkListPage.tsx
+++ b/client/src/pages/parks/ParkListPage.tsx
@@ -6,11 +6,17 @@ import { PageHeader } from '../../components/layout/PageHeader';
 import { Button } from '../../components/ui/Button';
 import { ParkCard } from '../../components/parks/ParkCard';
 import { Card } from '../../components/ui/Card';
+import { Select } from '../../components/ui/Select';
 import { LoadingSpinner } from '../../components/layout/LoadingSpinner';
 import { EmptyState } from '../../components/layout/EmptyState';
 import { parkApi, issueApi } from '../../services/api';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import { getIssueStatusDotColor } from '../../utils/issueStatusUtils';
+import {
+    getSafetyRiskBadgeColor,
+    getReportedSafetyRiskBadgeLabel,
+    getSafetyRiskLevelIndex
+} from '../../utils/issueSafetyRiskUtils';
 
 export const ParkListPage: React.FC = () => {
     const [parks, setParks] = useState<Park[]>([]);
@@ -19,6 +25,7 @@ export const ParkListPage: React.FC = () => {
     const [showInactive, setShowInactive] = useState(false);
     const [issues, setIssues] = useState<Issue[]>([]);
     const [recentIssuesOpen, setRecentIssuesOpen] = useState(true);
+    const [recentIssuesSort, setRecentIssuesSort] = useState<'recent' | 'severityHigh' | 'severityLow'>('recent');
 
     useEffect(() => {
         const fetchData = async () => {
@@ -109,10 +116,22 @@ export const ParkListPage: React.FC = () => {
         );
     }
 
-    // Get the most recent issues
-    const recentIssues = [...issues].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    ).slice(0, 5);
+    // Sort recent issues by selected steward preference.
+    const recentIssues = [...issues].sort((a, b) => {
+        const recencyDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+
+        if (recentIssuesSort === 'severityHigh') {
+            const severityDiff = getSafetyRiskLevelIndex(b.safetyRisk) - getSafetyRiskLevelIndex(a.safetyRisk);
+            return severityDiff !== 0 ? severityDiff : recencyDiff;
+        }
+
+        if (recentIssuesSort === 'severityLow') {
+            const severityDiff = getSafetyRiskLevelIndex(a.safetyRisk) - getSafetyRiskLevelIndex(b.safetyRisk);
+            return severityDiff !== 0 ? severityDiff : recencyDiff;
+        }
+
+        return recencyDiff;
+    }).slice(0, 5);
 
     return (
         <div>
@@ -141,12 +160,25 @@ export const ParkListPage: React.FC = () => {
                         <Card 
                             title="Recent Issues"
                             headerAction={
-                                <button
-                                    onClick={() => setRecentIssuesOpen(!recentIssuesOpen)}
-                                    className="text-gray-400 hover:text-gray-600 text-4xl"
-                                >
-                                    {recentIssuesOpen ? '▾' : '▸'}
-                                </button>
+                                <div className="flex items-center gap-3">
+                                    <Select
+                                        name="recentIssuesSort"
+                                        value={recentIssuesSort}
+                                        onChange={(value) => setRecentIssuesSort(value as 'recent' | 'severityHigh' | 'severityLow')}
+                                        options={[
+                                            { value: 'recent', label: 'Most Recent' },
+                                            { value: 'severityHigh', label: 'Highest Severity' },
+                                            { value: 'severityLow', label: 'Lowest Severity' }
+                                        ]}
+                                    />
+                                    <button
+                                        onClick={() => setRecentIssuesOpen(!recentIssuesOpen)}
+                                        className="text-gray-400 hover:text-gray-600 text-4xl"
+                                        aria-label={recentIssuesOpen ? 'Collapse recent issues' : 'Expand recent issues'}
+                                    >
+                                        {recentIssuesOpen ? '▾' : '▸'}
+                                    </button>
+                                </div>
                             }
                         >
                             {recentIssuesOpen && (
@@ -167,9 +199,17 @@ export const ParkListPage: React.FC = () => {
                                                         className="font-medium text-blue-600 hover:text-blue-500 truncate">
                                                         {issue.issueType.charAt(0).toUpperCase() + issue.issueType.slice(1)}
                                                     </Link>
-                                                    <span className="text-sm text-gray-500 whitespace-nowrap ml-4">
-                                                        {formatDistanceToNow(new Date(issue.createdAt), { addSuffix: true })}
-                                                    </span>
+                                                    <div className="ml-4 flex items-center gap-2 whitespace-nowrap">
+                                                        <span className={[
+                                                            'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold',
+                                                            getSafetyRiskBadgeColor(issue.safetyRisk)
+                                                        ].join(' ')}>
+                                                            {getReportedSafetyRiskBadgeLabel(issue.safetyRisk)}
+                                                        </span>
+                                                        <span className="text-sm text-gray-500">
+                                                            {formatDistanceToNow(new Date(issue.createdAt), { addSuffix: true })}
+                                                        </span>
+                                                    </div>
                                                 </div>
                                                 <p className="text-sm text-gray-600 mt-1 line-clamp-2">{issue.description}</p>
                                                 <p className="text-xs text-gray-500 mt-1 flex items-center">

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,6 +1,7 @@
 import {
     Park, Issue, IssueParams, IssueStatusEnum,
     IssueTypeEnum,
+    IssueRiskEnum,
     UserRoleEnum,
     User,
     IssuePin
@@ -237,6 +238,7 @@ export const issueApi = {
 
     updateIssue: async (issueId: number, data: {
         description?: string;
+        safetyRisk?: IssueRiskEnum;
         issueType?: IssueTypeEnum;
         isImagePublic?: boolean;
         parkId?: number;

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -117,7 +117,7 @@ export const issueApi = {
             params.append('issueTypes', t);
         }
 
-        params.append('statuses', IssueStatusEnum.OPEN);
+        params.append('statuses', IssueStatusEnum.UNRESOLVED);
         params.append('statuses', IssueStatusEnum.IN_PROGRESS);
 
         const response = await fetch(`${API_BASE_URL}/issues/map?${params.toString()}`, {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -17,7 +17,7 @@ export type Park = {
 };
 
 export enum IssueStatusEnum {
-    OPEN = 'OPEN',
+    UNRESOLVED = 'UNRESOLVED',
     IN_PROGRESS = 'IN_PROGRESS',
     RESOLVED = 'RESOLVED'
 }

--- a/client/src/types/leaflet.ts
+++ b/client/src/types/leaflet.ts
@@ -9,6 +9,14 @@ export type LeafletIconOptions = {
   popupAnchor?: [number, number];
 };
 
+export type LeafletDivIconOptions = {
+    className?: string;
+    html?: string;
+    iconSize?: [number, number];
+    iconAnchor?: [number, number];
+    popupAnchor?: [number, number];
+};
+
 export interface LeafletMap {
     setView: (center: [number, number], zoom: number) => LeafletMap;
 	fitBounds: (
@@ -51,6 +59,7 @@ export interface LeafletStatic {
     marker: (latlng: [number, number], options: Record<string, unknown>) => LeafletMarker;
     circle: (latlng: [number, number], options: Record<string, unknown>) => LeafletCircle;
 	icon: (options: LeafletIconOptions) => LeafletIcon;
+    divIcon: (options: LeafletDivIconOptions) => LeafletIcon;
 }
 
 // Extend the Window interface to include Leaflet

--- a/client/src/utils/issueSafetyRiskUtils.ts
+++ b/client/src/utils/issueSafetyRiskUtils.ts
@@ -72,7 +72,7 @@ export const getPassabilityBadgeLabel = (isPassable: boolean): string => {
 export const getPassabilityBadgeColor = (isPassable: boolean): string => {
     return isPassable
         ? 'bg-emerald-100 text-emerald-800 border border-emerald-200'
-    : 'bg-red-100 text-red-800 border border-red-200';
+        : 'bg-red-100 text-red-800 border border-red-200';
 };
 
 export const getSafetyRiskLevelIndex = (level: IssueRiskEnum): number => {

--- a/client/src/utils/issueSafetyRiskUtils.ts
+++ b/client/src/utils/issueSafetyRiskUtils.ts
@@ -4,8 +4,64 @@ export const getSafetyRiskLabel = (level: IssueRiskEnum): string => {
     switch (level) {
     case IssueRiskEnum.NO_RISK: return 'No Risk';
     case IssueRiskEnum.MINOR_RISK: return 'Minor Risk';
-    case IssueRiskEnum.SERIOUS_RISK: return 'Serious Risk/Immediate Danger';
+    case IssueRiskEnum.SERIOUS_RISK: return 'Serious Risk / Immediate Danger';
     default: return 'No Risk';
+    }
+};
+
+export const getSafetyRiskShortLabel = (level: IssueRiskEnum): string => {
+    switch (level) {
+    case IssueRiskEnum.NO_RISK:
+        return 'No Risk';
+    case IssueRiskEnum.MINOR_RISK:
+        return 'Minor';
+    case IssueRiskEnum.SERIOUS_RISK:
+        return 'Serious';
+    default:
+        return 'No Risk';
+    }
+};
+
+export const getReportedSafetyRiskBadgeLabel = (level: IssueRiskEnum): string => {
+    return `Reported ${getSafetyRiskShortLabel(level)}`;
+};
+
+export const getSafetyRiskDescription = (level: IssueRiskEnum): string => {
+    switch (level) {
+    case IssueRiskEnum.NO_RISK:
+        return 'Lowest level. Typically still passable and less severe than Minor Risk or Serious Risk / Immediate Danger.';
+    case IssueRiskEnum.MINOR_RISK:
+        return 'Middle level. More severe than No Risk, but below Serious Risk / Immediate Danger.';
+    case IssueRiskEnum.SERIOUS_RISK:
+        return 'Highest level. More severe than No Risk or Minor Risk and may require immediate attention.';
+    default:
+        return 'Lowest level. Typically still passable and less severe than Minor Risk or Serious Risk / Immediate Danger.';
+    }
+};
+
+export const getStewardSafetyRiskDescription = (level: IssueRiskEnum): string => {
+    switch (level) {
+    case IssueRiskEnum.NO_RISK:
+        return 'Reporter selected the lowest risk level available on the form, indicating they believed the issue was likely still passable and less severe than the other available options.';
+    case IssueRiskEnum.MINOR_RISK:
+        return 'Reporter selected the middle risk level available on the form, indicating they believed the issue was more severe than No Risk, but below Serious Risk / Immediate Danger.';
+    case IssueRiskEnum.SERIOUS_RISK:
+        return 'Reporter selected the highest risk level available on the form, indicating they believed the issue may need prompt attention.';
+    default:
+        return 'Reporter selected the lowest risk level available on the form.';
+    }
+};
+
+export const getSafetyRiskBadgeColor = (level: IssueRiskEnum): string => {
+    switch (level) {
+    case IssueRiskEnum.NO_RISK:
+        return 'bg-green-100 text-green-800 border border-green-200';
+    case IssueRiskEnum.MINOR_RISK:
+        return 'bg-yellow-100 text-yellow-800 border border-yellow-200';
+    case IssueRiskEnum.SERIOUS_RISK:
+        return 'bg-red-100 text-red-800 border border-red-200';
+    default:
+        return 'bg-gray-100 text-gray-800 border border-gray-200';
     }
 };
 

--- a/client/src/utils/issueSafetyRiskUtils.ts
+++ b/client/src/utils/issueSafetyRiskUtils.ts
@@ -29,22 +29,22 @@ export const getReportedSafetyRiskBadgeLabel = (level: IssueRiskEnum): string =>
 export const getSafetyRiskDescription = (level: IssueRiskEnum): string => {
     switch (level) {
     case IssueRiskEnum.NO_RISK:
-        return 'Lowest level. Typically still passable and less severe than Minor Risk or Serious Risk / Immediate Danger.';
+        return 'Small issue, safe to pass through.';
     case IssueRiskEnum.MINOR_RISK:
-        return 'Middle level. More severe than No Risk, but below Serious Risk / Immediate Danger.';
+        return 'Requires caution to avoid injury.';
     case IssueRiskEnum.SERIOUS_RISK:
-        return 'Highest level. More severe than No Risk or Minor Risk and may require immediate attention.';
+        return 'Dangerous condition, risk of serious harm.';
     default:
-        return 'Lowest level. Typically still passable and less severe than Minor Risk or Serious Risk / Immediate Danger.';
+        return 'Small issue, safe to pass through.';
     }
 };
 
 export const getStewardSafetyRiskDescription = (level: IssueRiskEnum): string => {
     switch (level) {
     case IssueRiskEnum.NO_RISK:
-        return 'Reporter selected the lowest risk level available on the form, indicating they believed the issue was likely still passable and less severe than the other available options.';
+        return 'Reporter selected the lowest risk level available on the form, indicating they believed the issue was safe to pass through.';
     case IssueRiskEnum.MINOR_RISK:
-        return 'Reporter selected the middle risk level available on the form, indicating they believed the issue was more severe than No Risk, but below Serious Risk / Immediate Danger.';
+        return 'Reporter selected the middle risk level available on the form, indicating they believed the issue required caution, but was not immediately dangerous.';
     case IssueRiskEnum.SERIOUS_RISK:
         return 'Reporter selected the highest risk level available on the form, indicating they believed the issue may need prompt attention.';
     default:

--- a/client/src/utils/issueSafetyRiskUtils.ts
+++ b/client/src/utils/issueSafetyRiskUtils.ts
@@ -29,13 +29,13 @@ export const getReportedSafetyRiskBadgeLabel = (level: IssueRiskEnum): string =>
 export const getSafetyRiskDescription = (level: IssueRiskEnum): string => {
     switch (level) {
     case IssueRiskEnum.NO_RISK:
-        return 'Small issue, safe to pass through.';
+        return 'Safe to pass through.';
     case IssueRiskEnum.MINOR_RISK:
         return 'Requires caution to avoid injury.';
     case IssueRiskEnum.SERIOUS_RISK:
         return 'Dangerous condition, risk of serious harm.';
     default:
-        return 'Small issue, safe to pass through.';
+        return 'Safe to pass through.';
     }
 };
 
@@ -63,6 +63,16 @@ export const getSafetyRiskBadgeColor = (level: IssueRiskEnum): string => {
     default:
         return 'bg-gray-100 text-gray-800 border border-gray-200';
     }
+};
+
+export const getPassabilityBadgeLabel = (isPassable: boolean): string => {
+    return isPassable ? 'Passable' : 'Unpassable';
+};
+
+export const getPassabilityBadgeColor = (isPassable: boolean): string => {
+    return isPassable
+        ? 'bg-emerald-100 text-emerald-800 border border-emerald-200'
+    : 'bg-red-100 text-red-800 border border-red-200';
 };
 
 export const getSafetyRiskLevelIndex = (level: IssueRiskEnum): number => {

--- a/client/src/utils/issueStatusUtils.ts
+++ b/client/src/utils/issueStatusUtils.ts
@@ -3,7 +3,7 @@ import { IssueStatusEnum } from '../types';
 
 export const getIssueStatusColor = (status: IssueStatusEnum): string => {
     switch (status) {
-    case IssueStatusEnum.UNRESOLVED: return 'bg-red-500 text-white';
+    case IssueStatusEnum.UNRESOLVED: return 'bg-red-100 text-red-700';
     case IssueStatusEnum.IN_PROGRESS: return 'bg-yellow-500 text-white';
     case IssueStatusEnum.RESOLVED: return 'bg-green-500 text-white';
     default: return 'bg-gray-500 text-white';
@@ -21,7 +21,7 @@ export const getIssueStatusTextColor = (status: IssueStatusEnum): string => {
 
 export const getIssueStatusDotColor = (status: IssueStatusEnum): string => {
     switch (status) {
-    case IssueStatusEnum.UNRESOLVED: return 'bg-red-500';
+    case IssueStatusEnum.UNRESOLVED: return 'bg-red-400';
     case IssueStatusEnum.IN_PROGRESS: return 'bg-yellow-500';
     case IssueStatusEnum.RESOLVED: return 'bg-green-500';
     default: return 'bg-gray-500';

--- a/client/src/utils/issueStatusUtils.ts
+++ b/client/src/utils/issueStatusUtils.ts
@@ -36,3 +36,25 @@ export const getIssueStatusLightBgColor = (status: IssueStatusEnum): string => {
     default: return 'bg-gray-100';
     }
 };
+
+export const getIssueStatusLabel = (status: IssueStatusEnum): string => {
+    switch (status) {
+    case IssueStatusEnum.UNRESOLVED: return 'Unresolved';
+    case IssueStatusEnum.IN_PROGRESS: return 'In Progress';
+    case IssueStatusEnum.RESOLVED: return 'Resolved';
+    default: return 'Unknown';
+    }
+};
+
+export const getIssueStatusTooltip = (status: IssueStatusEnum): string => {
+    switch (status) {
+    case IssueStatusEnum.UNRESOLVED:
+        return 'This issue has been reported and may still affect the trail.';
+    case IssueStatusEnum.IN_PROGRESS:
+        return 'Work is currently being done to fix this issue.';
+    case IssueStatusEnum.RESOLVED:
+        return 'This issue has been fixed and should no longer impact the trail.';
+    default:
+        return 'Issue status is unknown.';
+    }
+};

--- a/client/src/utils/issueStatusUtils.ts
+++ b/client/src/utils/issueStatusUtils.ts
@@ -3,7 +3,7 @@ import { IssueStatusEnum } from '../types';
 
 export const getIssueStatusColor = (status: IssueStatusEnum): string => {
     switch (status) {
-    case IssueStatusEnum.OPEN: return 'bg-red-500 text-white';
+    case IssueStatusEnum.UNRESOLVED: return 'bg-red-500 text-white';
     case IssueStatusEnum.IN_PROGRESS: return 'bg-yellow-500 text-white';
     case IssueStatusEnum.RESOLVED: return 'bg-green-500 text-white';
     default: return 'bg-gray-500 text-white';
@@ -12,7 +12,7 @@ export const getIssueStatusColor = (status: IssueStatusEnum): string => {
 
 export const getIssueStatusTextColor = (status: IssueStatusEnum): string => {
     switch (status) {
-    case IssueStatusEnum.OPEN: return 'text-red-600';
+    case IssueStatusEnum.UNRESOLVED: return 'text-red-600';
     case IssueStatusEnum.IN_PROGRESS: return 'text-yellow-600';
     case IssueStatusEnum.RESOLVED: return 'text-green-600';
     default: return 'text-gray-600';
@@ -21,7 +21,7 @@ export const getIssueStatusTextColor = (status: IssueStatusEnum): string => {
 
 export const getIssueStatusDotColor = (status: IssueStatusEnum): string => {
     switch (status) {
-    case IssueStatusEnum.OPEN: return 'bg-red-500';
+    case IssueStatusEnum.UNRESOLVED: return 'bg-red-500';
     case IssueStatusEnum.IN_PROGRESS: return 'bg-yellow-500';
     case IssueStatusEnum.RESOLVED: return 'bg-green-500';
     default: return 'bg-gray-500';
@@ -30,7 +30,7 @@ export const getIssueStatusDotColor = (status: IssueStatusEnum): string => {
 
 export const getIssueStatusLightBgColor = (status: IssueStatusEnum): string => {
     switch (status) {
-    case IssueStatusEnum.OPEN: return 'bg-red-100';
+    case IssueStatusEnum.UNRESOLVED: return 'bg-red-100';
     case IssueStatusEnum.IN_PROGRESS: return 'bg-yellow-100';
     case IssueStatusEnum.RESOLVED: return 'bg-green-100';
     default: return 'bg-gray-100';

--- a/server/docs/controllers/IssueController.md
+++ b/server/docs/controllers/IssueController.md
@@ -94,14 +94,14 @@ public async getMapPins(req: Request, res: Response)
 - **Params**:
   - `bbox` (string, required): The geographic bounding box (min/max latitude/longitude) to filter issues.
   - `issueTypes` (string[], optional): Filters issues by their type (e.g., obstruction, standing water/mud, other).
-  - `statuses` (string[], optional): Filters issues by their current status (e.g., OPEN, IN_PROGRESS)
+  - `statuses` (string[], optional): Filters issues by their current status (e.g., UNRESOLVED, IN_PROGRESS)
 - **Query Parameter**:
 
 ```md
 bbox=40.44,-80.0,40.50,-79.9
 &issueTypes=OBSTRUCTION
 &issueTypes=WATER
-&statuses=OPEN
+&statuses=UNRESOLVED
 &statuses=IN_PROGRESS
 ```
 
@@ -115,7 +115,7 @@ bbox=40.44,-80.0,40.50,-79.9
           "latitude": 40.44,
           "longitude": -79.99,
           "issueType": "OBSTRUCTION",
-          "status": "OPEN"
+          "status": "UNRESOLVED"
         }
       ]
     }

--- a/server/src/controllers/IssueController.ts
+++ b/server/src/controllers/IssueController.ts
@@ -212,10 +212,11 @@ export class IssueController {
         
         try {
             const { 
-                description, issueType, isImagePublic, parkId, latitude, longitude 
+                description, safetyRisk, issueType, isImagePublic, parkId, latitude, longitude 
             } = req.body;
             const issue = await this.issueService.updateIssue(issueId, {
                 description,
+                safetyRisk,
                 issueType,
                 isImagePublic,
                 parkId,

--- a/server/src/controllers/IssueController.ts
+++ b/server/src/controllers/IssueController.ts
@@ -309,7 +309,7 @@ export class IssueController {
     }
 
     private buildUnsubscribeHtml(title: string, message: string) {
-        const clientUrl = process.env.CLIENT_URL ?? 'http://localhost:5173';
+        const clientUrl = (process.env.CLIENT_URL?.trim() || 'http://localhost:5173').replace(/\/+$/, '');
         return `<!doctype html>
 <html lang="en">
 <head>

--- a/server/src/prisma/migrations/20250423205303_init_db/migration.sql
+++ b/server/src/prisma/migrations/20250423205303_init_db/migration.sql
@@ -1,5 +1,5 @@
 -- CreateEnum
-CREATE TYPE "IssueStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED');
+CREATE TYPE "IssueStatus" AS ENUM ('UNRESOLVED', 'IN_PROGRESS', 'RESOLVED');
 
 -- CreateEnum
 CREATE TYPE "IssueType" AS ENUM ('OBSTRUCTION', 'WATER', 'OTHER');
@@ -39,7 +39,7 @@ CREATE TABLE "Issue" (
     "park_id" INTEGER NOT NULL,
     "trail_id" INTEGER NOT NULL,
     "is_public" BOOLEAN NOT NULL,
-    "status" "IssueStatus" NOT NULL DEFAULT 'OPEN',
+    "status" "IssueStatus" NOT NULL DEFAULT 'UNRESOLVED',
     "description" VARCHAR(150),
     "issue_type" "IssueType" NOT NULL,
     "urgency" "Urgency" NOT NULL DEFAULT 'MEDIUM',

--- a/server/src/prisma/migrations/20250424205414_changing_enum_name/migration.sql
+++ b/server/src/prisma/migrations/20250424205414_changing_enum_name/migration.sql
@@ -8,7 +8,7 @@
 
 */
 -- CreateEnum
-CREATE TYPE "IssueStatusEnum" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED');
+CREATE TYPE "IssueStatusEnum" AS ENUM ('UNRESOLVED', 'IN_PROGRESS', 'RESOLVED');
 
 -- CreateEnum
 CREATE TYPE "IssueTypeEnum" AS ENUM ('OBSTRUCTION', 'WATER', 'OTHER');
@@ -21,7 +21,7 @@ CREATE TYPE "UserRoleEnum" AS ENUM ('ROLE_USER', 'ROLE_ADMIN', 'ROLE_SUPERADMIN'
 
 -- AlterTable
 ALTER TABLE "Issue" DROP COLUMN "status",
-ADD COLUMN     "status" "IssueStatusEnum" NOT NULL DEFAULT 'OPEN',
+ADD COLUMN     "status" "IssueStatusEnum" NOT NULL DEFAULT 'UNRESOLVED',
 DROP COLUMN "issue_type",
 ADD COLUMN     "issue_type" "IssueTypeEnum" NOT NULL,
 DROP COLUMN "urgency",

--- a/server/src/prisma/migrations/20260316002429_add_issue_groups/migration.sql
+++ b/server/src/prisma/migrations/20260316002429_add_issue_groups/migration.sql
@@ -5,7 +5,7 @@ ALTER TABLE "Issue" ADD COLUMN     "issue_group_id" INTEGER;
 CREATE TABLE "IssueGroup" (
     "issue_group_id" SERIAL NOT NULL,
     "primary_issue_id" INTEGER,
-    "status" "IssueStatusEnum" NOT NULL DEFAULT 'OPEN',
+    "status" "IssueStatusEnum" NOT NULL DEFAULT 'UNRESOLVED',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL,
 

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 }
 
 enum IssueStatusEnum {
-  OPEN
+  UNRESOLVED
   IN_PROGRESS
   RESOLVED
 }
@@ -51,7 +51,7 @@ model Issue {
   parkId         Int                                              @map("park_id")
   isPublic       Boolean                                          @map("is_public")  
   isImagePublic  Boolean          @default(false)                 @map("is_image_public")
-  status         IssueStatusEnum  @default(OPEN)
+  status         IssueStatusEnum  @default(UNRESOLVED)
   description    String?          @db.VarChar(450)
   issueType      IssueTypeEnum                                    @map("issue_type")
   safetyRisk     IssueRiskEnum
@@ -72,7 +72,7 @@ model Issue {
 model IssueGroup {
   issueGroupId Int              @id @default(autoincrement())   @map("issue_group_id")
   primaryIssueId Int?                                           @map("primary_issue_id")
-  status       IssueStatusEnum  @default(OPEN)
+  status       IssueStatusEnum  @default(UNRESOLVED)
   createdAt    DateTime         @default(now())                 @map("created_at")
   updatedAt    DateTime         @updatedAt                      @map("updated_at")
   issues       Issue[]

--- a/server/src/prisma/seed.ts
+++ b/server/src/prisma/seed.ts
@@ -106,7 +106,7 @@ async function main() {
 
     const groupedIssue = await prisma.issueGroup.create({
         data: {
-            status: IssueStatusEnum.OPEN,
+            status: IssueStatusEnum.UNRESOLVED,
         }
     });
 
@@ -122,7 +122,7 @@ async function main() {
             description: 'Heavy rainfall caused water pooling on the trail.',
             isPublic: true,
             isImagePublic: false,
-            status: IssueStatusEnum.OPEN,
+            status: IssueStatusEnum.UNRESOLVED,
             notifyReporter: true,
             reporterEmail: 'john@example.com',
             ownerEmail: 'john@example.com',
@@ -141,7 +141,7 @@ async function main() {
             description: 'A second report of the same obstruction farther along the same park trail.',
             isPublic: true,
             isImagePublic: false,
-            status: IssueStatusEnum.OPEN,
+            status: IssueStatusEnum.UNRESOLVED,
             notifyReporter: true,
             reporterEmail: 'jane@example.com',
             ownerEmail: 'jane@example.com',
@@ -166,7 +166,7 @@ async function main() {
             description: 'Severe erosion has made the path unsafe for bikers.',
             isPublic: true,
             isImagePublic: false,
-            status: IssueStatusEnum.OPEN,
+            status: IssueStatusEnum.UNRESOLVED,
             notifyReporter: true,
             reporterEmail: 'mike@example.com',
             ownerEmail: 'mike@example.com'

--- a/server/src/repositories/IssueRepository.ts
+++ b/server/src/repositories/IssueRepository.ts
@@ -1,5 +1,5 @@
 import {
-    IssueStatusEnum, IssueTypeEnum, Prisma
+    IssueStatusEnum, IssueTypeEnum, IssueRiskEnum, Prisma
 } from '@prisma/client';
 
 import { isNotFoundError, prisma } from '@/prisma/prismaClient';
@@ -471,6 +471,7 @@ export class IssueRepository {
 
     public async updateIssue(issueId: number, data: Partial<{
         description?: string;
+        safetyRisk?: IssueRiskEnum;
         issueType?: IssueTypeEnum;
 		isImagePublic?: boolean;
 		parkId?: number;
@@ -482,6 +483,7 @@ export class IssueRepository {
                 where: { issueId: issueId },
                 data: {
                     ...(data.description !== undefined && { description: data.description }),
+                    ...(data.safetyRisk !== undefined && { safetyRisk: data.safetyRisk }),
                     ...(data.issueType !== undefined && { issueType: data.issueType }),
                     ...(data.isImagePublic !== undefined && { isImagePublic: data.isImagePublic }),
                     ...(data.parkId !== undefined && { parkId: data.parkId }),

--- a/server/src/schemas/issueSchema.ts
+++ b/server/src/schemas/issueSchema.ts
@@ -43,9 +43,9 @@ export const getIssueMapPinsSchema = z.object({
             .union([z.nativeEnum(IssueStatusEnum), z.array(z.nativeEnum(IssueStatusEnum))])
             .transform((v) => (
                 v === undefined ? [
-                    IssueStatusEnum.OPEN, IssueStatusEnum.IN_PROGRESS
+                    IssueStatusEnum.UNRESOLVED, IssueStatusEnum.IN_PROGRESS
                 ] : Array.isArray(v) ? v : [v]))
-            .default([IssueStatusEnum.OPEN, IssueStatusEnum.IN_PROGRESS]),
+            .default([IssueStatusEnum.UNRESOLVED, IssueStatusEnum.IN_PROGRESS]),
     })
 });
 
@@ -92,7 +92,7 @@ export const createIssueSchema = z.object({
         passible: z.boolean().default(false),
         isPublic: z.boolean().default(false),
         isImagePublic: z.boolean().default(false),
-        status: z.nativeEnum(IssueStatusEnum).default(IssueStatusEnum.OPEN),
+        status: z.nativeEnum(IssueStatusEnum).default(IssueStatusEnum.UNRESOLVED),
         latitude: z.number().optional(),
         longitude: z.number().optional(),
         reporterEmail: z.string().email().optional(),

--- a/server/src/services/IssueNotificationService.ts
+++ b/server/src/services/IssueNotificationService.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import jwt from 'jsonwebtoken';
 
 import { EmailClient, MailgunEmailClient } from '@/services/email';
+import { logger } from '@/utils/logger';
 
 type IssueWithRelations = Prisma.IssueGetPayload<{
     include: {
@@ -26,8 +27,21 @@ export class IssueNotificationService {
         this.unsubscribeSecret =
             process.env.ISSUE_NOTIFICATION_UNSUBSCRIBE_SECRET ??
             process.env.JWT_SECRET;
-        this.clientBaseUrl = process.env.CLIENT_URL ?? 'http://localhost:5173';
-        this.serverBaseUrl = process.env.SERVER_URL ?? 'http://localhost:3000';
+
+        const isProduction = process.env.NODE_ENV === 'production';
+        const configuredClientUrl = process.env.CLIENT_URL?.trim();
+        const configuredServerUrl = process.env.SERVER_URL?.trim();
+
+        if (isProduction && !configuredClientUrl) {
+            logger.error('CLIENT_URL is missing in production. Email links will fallback to localhost.');
+        }
+
+        if (isProduction && !configuredServerUrl) {
+            logger.warn('SERVER_URL is missing in production. Unsubscribe links will fallback to CLIENT_URL/localhost.');
+        }
+
+        this.clientBaseUrl = (configuredClientUrl || 'http://localhost:5173').replace(/\/+$/, '');
+        this.serverBaseUrl = (configuredServerUrl || this.clientBaseUrl || 'http://localhost:3000').replace(/\/+$/, '');
     }
 
     public canSendEmails() {

--- a/server/src/services/IssueService.ts
+++ b/server/src/services/IssueService.ts
@@ -1,5 +1,5 @@
 import {
-    IssueTypeEnum, IssueStatusEnum
+    IssueTypeEnum, IssueStatusEnum, IssueRiskEnum
 } from '@prisma/client';
 import { v4 as uuid } from 'uuid';
 
@@ -274,6 +274,7 @@ export class IssueService {
 
     public async updateIssue(issueId: number, data: {
         description?: string;
+        safetyRisk?: IssueRiskEnum;
         issueType?: IssueTypeEnum;
         isImagePublic?: boolean;
         parkId?: number;

--- a/server/test/integration/issueRoutes.test.ts
+++ b/server/test/integration/issueRoutes.test.ts
@@ -90,7 +90,7 @@ describe('Issue API End-to-End', () => {
             issueType: 'OBSTRUCTION' as IssueTypeEnum,
             safetyRisk: 'NO_RISK' as IssueRiskEnum,
             reporterEmail: 'sample1@example.com',
-            status: 'OPEN' as IssueStatusEnum,
+            status: 'UNRESOLVED' as IssueStatusEnum,
             notifyReporter: true,
             isPublic: true,
             description: 'Flooding trail again'
@@ -128,7 +128,7 @@ describe('Issue API End-to-End', () => {
             issueType: 'WATER' as IssueTypeEnum,
             safetyRisk: 'MINOR_RISK' as IssueRiskEnum,
             reporterEmail: 'sample2@example.com',
-            status: 'OPEN' as IssueStatusEnum,
+            status: 'UNRESOLVED' as IssueStatusEnum,
             notifyReporter: true,
             isPublic: true,
             description: 'A related water report'
@@ -150,7 +150,7 @@ describe('Issue API End-to-End', () => {
             issueType: 'OTHER' as IssueTypeEnum,
             safetyRisk: 'NO_RISK' as IssueRiskEnum,
             reporterEmail: 'sample-cross-park@example.com',
-            status: 'OPEN' as IssueStatusEnum,
+            status: 'UNRESOLVED' as IssueStatusEnum,
             notifyReporter: true,
             isPublic: true,
             description: 'Issue in a different park'
@@ -231,10 +231,10 @@ describe('Issue API End-to-End', () => {
         const reopenRes = await request(app)
             .put(`/api/issues/${createdIssueId}/status`)
             .set('Authorization', 'Bearer TEST_TOKEN')
-            .send({ status: 'OPEN' as IssueStatusEnum });
+            .send({ status: 'UNRESOLVED' as IssueStatusEnum });
 
         expect(reopenRes.status).toBe(200);
-        expect(reopenRes.body.issue.status).toBe('OPEN');
+        expect(reopenRes.body.issue.status).toBe('UNRESOLVED');
 
         const secondIssueRes = await request(app)
             .get(`/api/issues/${secondIssueId}`)
@@ -265,7 +265,7 @@ describe('Issue API End-to-End', () => {
             issueType: 'OTHER' as IssueTypeEnum,
             safetyRisk: 'NO_RISK' as IssueRiskEnum,
             reporterEmail: 'sample3@example.com',
-            status: 'OPEN' as IssueStatusEnum,
+            status: 'UNRESOLVED' as IssueStatusEnum,
             notifyReporter: true,
             isPublic: true,
             isImagePublic: true,

--- a/server/test/unit/issueService.test.ts
+++ b/server/test/unit/issueService.test.ts
@@ -29,7 +29,7 @@ describe('IssueService', () => {
         description: 'Trail is flooded',
         isPublic: true,
         isImagePublic: false,
-        status: IssueStatusEnum.OPEN,
+        status: IssueStatusEnum.UNRESOLVED,
         notifyReporter: true,
         reporterEmail: 'reporter@example.com',
         ownerEmail: 'reporter@example.com',
@@ -93,7 +93,7 @@ describe('IssueService', () => {
             longitude: -79.9901,
             isPublic: true,
             isImagePublic: false,
-            status: IssueStatusEnum.OPEN,
+            status: IssueStatusEnum.UNRESOLVED,
             notifyReporter: true,
             imageMetadata: {
                 contentType: 'image/jpeg'
@@ -239,7 +239,7 @@ describe('IssueService', () => {
             issueGroup: {
                 issueGroupId: 10,
                 primaryIssueId: 1,
-                status: IssueStatusEnum.OPEN,
+                status: IssueStatusEnum.UNRESOLVED,
                 issues: [{ issueId: 1 }, { issueId: 2 }],
             },
         } as Awaited<ReturnType<IssueRepository['getIssue']>>);


### PR DESCRIPTION
- Renamed issue status from "open" to "unresolved" across client, server, schema, migrations, etc.
- Updated safety risk wording to be relative and user-reported, added steward-facing descriptions and badges on dashboard for quick scan (Reported Serious, Reported Minor, and Reported No Risk)
- Updated dashboard views with recent issue sorting by severity or submission date, made more consistent green/yellow/red color usage
- Changed the homepage from View Parks to View Issues
- Replaced the current location marker with a blue dot (stick to modern map conventions)