### PR TITLE
Added IT and unit test for getMapPins API call

### DIFF
--- a/server/test/integration/issueRoutes.test.ts
+++ b/server/test/integration/issueRoutes.test.ts
@@ -24,6 +24,7 @@ let createdIssueId: number | undefined;
 let secondIssueId: number | undefined;
 let crossParkIssueId: number | undefined;
 let imagePublicIssueId: number | undefined;
+let createdAt: string;
 
 jest.mock('../../src/middlewares/index', () => ({
   ...jest.requireActual('../../src/middlewares/index'),
@@ -93,7 +94,9 @@ describe('Issue API End-to-End', () => {
             status: 'OPEN' as IssueStatusEnum,
             notifyReporter: true,
             isPublic: true,
-            description: 'Flooding trail again'
+            description: 'Tree down again',
+			longitude: -79.9959,
+			latitude: 40.4406
         };
     
         const res = await request(app)
@@ -109,6 +112,7 @@ describe('Issue API End-to-End', () => {
         });
 
         createdIssueId = res.body.issue.issueId; 
+		createdAt = res.body.issue.createdAt;
     });
 
     it('GET /api/issues/:issueId -> should return the created issue', async () => {
@@ -121,6 +125,60 @@ describe('Issue API End-to-End', () => {
         expect(res.body.issue.issueId).toBe(createdIssueId);
         expect(createdIssueId).toBeDefined();
     });
+
+	it('GET /api/issues/map -> should return map pins for issues', async () => {
+		const payload2 = {
+            parkId,
+            issueType: 'WATER' as IssueTypeEnum,
+            safetyRisk: 'MINOR_RISK' as IssueRiskEnum,
+            reporterEmail: 'sample2@example.com',
+            status: 'OPEN' as IssueStatusEnum,
+            notifyReporter: true,
+            isPublic: true,
+            description: 'Flooding trail again',
+			longitude: -79.9960,
+			latitude: 40.4407
+        };
+
+		const sendRes = await request(app)
+            .post('/api/issues')
+            .set('Authorization', 'Bearer TEST_TOKEN')
+            .send(payload2);
+
+		const createdIssueId2 = sendRes.body.issue.issueId; 
+		const createdAt2 = sendRes.body.issue.createdAt;
+
+		const bbox = '40.4306,-80.0059,40.4506,-79.9859';
+
+		const res = await request(app)
+			.get('/api/issues/map')
+			.set('Authorization', 'Bearer TEST_TOKEN')
+			.query({
+				bbox,
+				issueTypes: ['OBSTRUCTION', 'WATER'],
+				statuses: ['OPEN', 'IN_PROGRESS']
+			});
+
+		expect(res.status).toBe(200);
+		expect(Array.isArray(res.body.pins)).toBe(true);
+		expect(res.body.pins.length).toBe(2);
+
+		const pin1 = res.body.pins.find((pin: any) => pin.issueId === createdIssueId);
+		expect(pin1).toBeDefined();
+		expect(pin1.issueType).toBe('OBSTRUCTION');
+		expect(pin1.status).toBe('OPEN');
+		expect(pin1.latitude).toBe(40.4406);
+		expect(pin1.longitude).toBe(-79.9959);
+		expect(pin1.createdAt).toBe(createdAt);
+
+		const pin2 = res.body.pins.find((pin: any) => pin.issueId === createdIssueId2);
+		expect(pin2).toBeDefined();
+		expect(pin2.issueType).toBe('WATER');
+		expect(pin2.status).toBe('OPEN');
+		expect(pin2.latitude).toBe(40.4407);
+		expect(pin2.longitude).toBe(-79.9960);
+		expect(pin2.createdAt).toBe(createdAt2);
+	});
 
     it('POST /api/issues -> should create a second issue for group tests', async () => {
         const payload = {

--- a/server/test/unit/issueService.test.ts
+++ b/server/test/unit/issueService.test.ts
@@ -206,6 +206,22 @@ describe('IssueService', () => {
         ]);
     });
 
+	test('should get map pins for issues within bounding box and filters', async () => {
+		const issues = [baseIssue];
+		issueRepositoryMock.getMapPins.mockResolvedValue(issues);
+
+		const result = await issueService.getMapPins(40.4306, -80.0059, 40.4506, -79.9859, [IssueTypeEnum.WATER], [IssueStatusEnum.OPEN]);
+
+		expect(issueRepositoryMock.getMapPins).toHaveBeenCalledWith(40.4306, -80.0059, 40.4506, -79.9859, [IssueTypeEnum.WATER], [IssueStatusEnum.OPEN]);
+		expect(result.length).toBe(1);
+		expect(result[0].issueId).toBe(baseIssue.issueId);
+		expect(result[0].issueType).toBe(baseIssue.issueType);
+		expect(result[0].status).toBe(baseIssue.status);
+		expect(result[0].createdAt).toBe(baseIssue.createdAt);
+		expect(result[0].latitude).toBe(baseIssue.latitude);
+		expect(result[0].longitude).toBe(baseIssue.longitude);
+	});
+
     test('should update issue status', async () => {
         const updated = { ...baseIssue, status: IssueStatusEnum.RESOLVED, resolvedAt: new Date() };
         issueRepositoryMock.getIssue.mockResolvedValue(baseIssue);
@@ -282,4 +298,40 @@ describe('IssueService', () => {
 
         expect(issueRepositoryMock.setIssueGroupMembers).not.toHaveBeenCalled();
     });
+
+	test('should update an issue', async () => {
+		const data = {
+			description: 'Tree is down blocking the path',
+			issueType: IssueTypeEnum.OBSTRUCTION,
+			parkId: 2,
+			longitude: -79.9905,
+			latitude: 40.4407,
+		}
+		const updatedIssue = {
+			...baseIssue,
+			...data
+		}
+
+		const {
+            issueImage: _updatedIssueImage,
+            ...updatedWithoutImage
+        } = updatedIssue;
+
+		issueRepositoryMock.getIssue.mockResolvedValue(baseIssue);
+		issueRepositoryMock.updateIssue.mockResolvedValue(updatedIssue);
+
+		const initial = await issueService.getIssue(1);
+		expect(initial).toEqual({
+			...baseIssueWithoutImage,
+			issueGroupId: null,
+			issueGroupMemberIds: [baseIssue.issueId],
+		});
+
+		const result = await issueService.updateIssue(1, data);
+		expect(result).toEqual({
+             ...updatedWithoutImage,
+            issueGroupId: null,
+            issueGroupMemberIds: [updatedIssue.issueId],
+        });
+	});
 });


### PR DESCRIPTION
Added tests:
- IT: creates two issues that are nearby, then call /issues/map API with bbox and issue type filter to verify that it returns exactly those two issues.
- Unit (get map pin): ensures that issueService.getMapPins returns expected base issue via the call to issueRepository
- Unit (update issue): ensures that any updates (including description, issue type, park id, longitude/latitude) works and returned issue is updated as expected.