### PR TITLE
Address feedback from user testing

### DIFF
--- a/client/src/components/issues/IssueList.tsx
+++ b/client/src/components/issues/IssueList.tsx
@@ -23,7 +23,7 @@ export const IssueList: React.FC<IssueListProps> = ({
         return (
             <EmptyState
                 title={emptyStateMessage}
-                description="Issues will appear here once they are reported."
+                description="Please double check filtering options. Otherwise, issues will appear here once they are reported."
                 action={
                     <Link to="/issues/report">
                         <Button variant="primary">Report an Issue</Button>

--- a/client/src/components/issues/IssueReportForm.tsx
+++ b/client/src/components/issues/IssueReportForm.tsx
@@ -4,10 +4,7 @@ import React, { useState, useEffect } from 'react';
 import {
     Park, ImageMetadata, IssueParams, IssueStatusEnum, IssueTypeEnum, IssueRiskEnum
 } from '../../types';
-import {
-    getSafetyRiskDescription,
-    getSafetyRiskLabel,
-} from '../../utils/issueSafetyRiskUtils';
+import { getSafetyRiskLabel } from '../../utils/issueSafetyRiskUtils';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { Alert } from '../ui/Alert';
@@ -542,7 +539,6 @@ export const IssueReportForm: React.FC<IssueReportFormProps> = ({ onSubmit }) =>
                                     `}
                                 >
                                     <div className="text-sm font-medium">{getSafetyRiskLabel(level)}</div>
-                                    <p className="mt-1 text-xs text-gray-600">{getSafetyRiskDescription(level)}</p>
                                 </button>
                             ))}
                         </div>

--- a/client/src/components/ui/ImageUpload.tsx
+++ b/client/src/components/ui/ImageUpload.tsx
@@ -194,6 +194,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
             ${error ? 'border-red-300' : ''}
             ${isProcessing ? 'opacity-70' : ''}
             transition-colors cursor-pointer`}
+                onClick={() => inputRef.current?.click()}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
@@ -221,23 +222,20 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
                                 strokeLinejoin="round"
                             />
                         </svg>
-                        <div className="flex text-lg text-gray-600 ">
-                            <label
-                                htmlFor="file-upload"
-                                className="relative cursor-pointer rounded-md font-medium text-blue-600 hover:text-blue-500 focus-within:outline-none"
-                            >
-                                <span>Upload a file</span>
-                                <input
-                                    id="file-upload"
-                                    name="file-upload"
-                                    type="file"
-                                    className="sr-only"
-                                    accept={acceptedFormats}
-                                    onChange={handleFileChange}
-                                    ref={inputRef}
-                                />
-                            </label>
-                            <p className="pl-1">or drag and drop</p>
+                        <div className="flex justify-center text-lg text-gray-600 ">
+                            <span className="font-medium text-blue-600">
+								Upload an image
+                            </span>
+                            <input
+                                id="file-upload"
+                                name="file-upload"
+                                type="file"
+                                className="sr-only"
+                                accept={acceptedFormats}
+                                onChange={handleFileChange}
+                                ref={inputRef}
+                            />
+	
                         </div>
                         <p className="text-xs text-gray-500">PNG, JPG, GIF, HEIC up to 10MB</p>
                     </div>

--- a/client/src/components/ui/Select.tsx
+++ b/client/src/components/ui/Select.tsx
@@ -13,6 +13,7 @@ interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>
     fullWidth?: boolean;
     onChange?: (value: string) => void;
     helperText?: string;
+	sortOptions?: boolean;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -25,6 +26,7 @@ export const Select: React.FC<SelectProps> = ({
     onChange,
     helperText,
     disabled,
+    sortOptions = true,
     ...props
 }) => {
     const selectId = id || label?.toLowerCase().replace(/\s+/g, '-');
@@ -36,13 +38,16 @@ export const Select: React.FC<SelectProps> = ({
         }
     };
 
-    const defaultOptions = options.filter((option) => option.value === '');
-    const otherOptions = options.filter((option) => option.value !== '');
+    let sortedOptions = options;
+    if (sortOptions) {
+        const defaultOptions = options.filter((option) => option.value === '');
+        const otherOptions = options.filter((option) => option.value !== '');
 
-    const sortedOptions = [
-        ...defaultOptions,
-        ...otherOptions.sort((a, b) => a.label.localeCompare(b.label)),
-    ];
+        sortedOptions = [
+            ...defaultOptions,
+            ...otherOptions.sort((a, b) => a.label.localeCompare(b.label)),
+        ];
+    }
 
     return (
         <div className={`${widthClass} ${className} mb-2`}>

--- a/client/src/pages/issues/IssueDetailCard.tsx
+++ b/client/src/pages/issues/IssueDetailCard.tsx
@@ -871,7 +871,7 @@ export const IssueDetailCard: React.FC<{
                                                     <div className={isEditing ? '' : 'mt-4'}>
                                                         <div className="text-md font-medium text-black bold">Photo Visibility</div>
                                                         <div className="mt-2 text-sm text-gray-600">
-                                                            {isImagePublic ? 'Photo is currently visible to all users.' : 'Photo is currently visible only to stewards/admins.'}
+                                                            {isImagePublic ? 'Photo is visible to everyone.' : 'Photo is only visible to admins.'}
                                                         </div>
                                                         <div className="mt-2">
                                                             <Button
@@ -881,7 +881,7 @@ export const IssueDetailCard: React.FC<{
                                                                 isLoading={isUpdatingPhotoVisibility}
                                                                 disabled={isUpdatingPhotoVisibility}
                                                             >
-                                                                {isImagePublic ? 'Revoke Public Photo Approval' : 'Approve for Public View'}
+                                                                {isImagePublic ? 'Make Private' : 'Make Public'}
                                                             </Button>
                                                         </div>
                                                     </div>

--- a/client/src/pages/issues/IssueReportPage.tsx
+++ b/client/src/pages/issues/IssueReportPage.tsx
@@ -51,6 +51,15 @@ export const IssueReportPage: React.FC = () => {
                 subtitle="Help us keep our trails in great condition by reporting issues you encounter"
             />
 
+            <div className="mt-10 max-w-3xl mx-auto bg-blue-50 p-4 rounded-lg border border-blue-200">
+                <h3 className="text-sm font-semibold text-blue-600 mb-1">
+					Sign in or opt-in email notification to edit this report later.
+                </h3>
+                <p className="text-sm italic text-blue-600">
+					Otherwise, you won’t be able to make changes to this report.
+                </p>
+            </div>
+
             {!isGeolocationSupported && !isSubmitted && (
                 <Alert variant="warning" className="mb-6">
                     Your device or browser doesn't support location services. You can still submit the report, but we won't be able to automatically detect the issue location.
@@ -134,7 +143,10 @@ export const IssueReportPage: React.FC = () => {
                             </h2>
 
                             <p className="text-lg text-gray-600 max-w-lg mb-8">
-                                The issue has been successfully reported. We appreciate your help in maintaining our trails.
+                                The issue has been successfully reported.
+                            </p>
+                            <p className="text-lg italic text-gray-600 max-w-lg mb-8">
+								You can view reported issue on either Issues or Profile page.
                             </p>
 
                             <Button variant="primary" onClick={handleSubmitAnother}>

--- a/client/src/pages/parks/ParkDetailPage.tsx
+++ b/client/src/pages/parks/ParkDetailPage.tsx
@@ -1,30 +1,61 @@
 // src/pages/parks/ParkDetailPage.tsx
 import React, { useState, useEffect } from 'react';
 import {
-    Link, useParams, useNavigate
+    Link, useParams, useNavigate,
+    useLocation
 } from 'react-router-dom';
 import {
     Park, Issue, IssueStatusEnum
 } from '../../types';
 import { PageHeader } from '../../components/layout/PageHeader';
 import { Button } from '../../components/ui/Button';
-import { Card } from '../../components/ui/Card';
-import { Badge } from '../../components/ui/Badge';
 import { LoadingSpinner } from '../../components/layout/LoadingSpinner';
 import { EmptyState } from '../../components/layout/EmptyState';
 import { IssueList } from '../../components/issues/IssueList';
 import {
     parkApi, issueApi
 } from '../../services/api';
+import { Select } from '../../components/ui/Select';
 
 export const ParkDetailPage: React.FC = () => {
     const { parkId } = useParams<{ parkId: string }>();
     const navigate = useNavigate();
+    const location = useLocation();
     
     const [park, setPark] = useState<Park | null>(null);
     const [issues, setIssues] = useState<Issue[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+
+    const [statuses, setStatuses] = useState<IssueStatusEnum[]>([
+        IssueStatusEnum.UNRESOLVED,
+        IssueStatusEnum.IN_PROGRESS,
+    ]);
+
+    const [datePreset, setDatePreset] = useState<'7d' | '30d' | '3m' | '6m' | 'all'>('6m');
+
+    const getDateRange = () => {
+        const now = new Date();
+
+        if (datePreset === 'all') 
+        {return {};}
+
+        const start = new Date();
+
+        if (datePreset === '7d') 
+        {start.setDate(now.getDate() - 7);}
+        if (datePreset === '30d') 
+        {start.setDate(now.getDate() - 30);}
+        if (datePreset === '3m') 
+        {start.setMonth(now.getMonth() - 3);}
+        if (datePreset === '6m') 
+        {start.setMonth(now.getMonth() - 6);}
+
+        return {
+            startDate: start.toISOString(),
+            endDate: now.toISOString(),
+        };
+    };
 
     useEffect(() => {
         const fetchParkData = async () => {
@@ -49,10 +80,9 @@ export const ParkDetailPage: React.FC = () => {
                 setPark(parkData);
                 
                 // Fetch issues for this park
-                const issuesData = await issueApi.getIssuesByPark(id);
-                // Filter to only show public issues or unresolved issues
-                const filteredIssues = issuesData.filter((issue) => issue.isPublic);
-                setIssues(filteredIssues);
+                const { startDate, endDate } = getDateRange();
+                const issuesData = await issueApi.getIssuesByPark(id, statuses, startDate, endDate);
+                setIssues(issuesData);
             } catch (err) {
                 // eslint-disable-next-line no-console
                 console.error('Error fetching park details:', err);
@@ -63,7 +93,7 @@ export const ParkDetailPage: React.FC = () => {
         };
 
         fetchParkData();
-    }, [parkId]);
+    }, [parkId, statuses, datePreset, location.key]);
 
     if (isLoading) {
         return <LoadingSpinner />;
@@ -85,9 +115,6 @@ export const ParkDetailPage: React.FC = () => {
             </div>
         );
     }
-
-    // Count unresolved issues
-    const unresolvedIssuesCount = issues.filter((issue) => issue.status === IssueStatusEnum.UNRESOLVED).length;
 
     return (
         <div>
@@ -112,48 +139,50 @@ export const ParkDetailPage: React.FC = () => {
                 }
             />
 
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-                <Card className="lg:col-span-2">
-                    <div className="flex justify-between mb-4">
-                        <h3 className="text-xl font-bold text-gray-900">Park Information</h3>
-                        {park.isActive ? (
-                            <Badge variant="success">Active</Badge>
-                        ) : (
-                            <Badge variant="secondary">Inactive</Badge>
-                        )}
-                    </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-y-4 gap-x-6">
-                        <div>
-                            <p className="text-sm font-medium text-gray-500">County</p>
-                            <p className="mt-1 text-base text-gray-900">{park.county}</p>
-                        </div>
-                    </div>
-                </Card>
-
-                <Card>
-                    <h3 className="text-xl font-bold text-gray-900 mb-4">Quick Stats</h3>
-                    <div className="space-y-4">
-                        <div>
-                            <p className="text-sm font-medium text-gray-500">Unresolved Issues</p>
-                            <p className="mt-1 text-2xl font-semibold text-red-600">{unresolvedIssuesCount}</p>
-                        </div>
-                    </div>
-                </Card>
-            </div>
-
             <div>
-                <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-2xl font-bold text-gray-900">Recent Issues</h2>
-                    <Link to={`/issues/report?parkId=${park.parkId}`} className="text-sm text-blue-600 hover:text-blue-500 font-medium">
-                        Report Issue
-                    </Link>
+			    <div className="flex flex-wrap gap-4 items-center mb-4">
+                    {/* Status filter */}
+                    <div className="flex gap-2">
+                        {Object.values(IssueStatusEnum).map((status) => (
+                            <Button
+                                key={status}
+                                variant={statuses.includes(status) ? 'primary' : 'secondary'}
+  							size="sm"
+                                onClick={() => {
+                                    setStatuses((prev) =>
+                                        prev.includes(status)
+                                            ? prev.filter((s) => s !== status)
+                                            : [...prev, status]);
+                                }}
+                                className="rounded-full"
+                            >
+                                {status.replace('_', ' ')}
+                            </Button>
+                        ))}
+                    </div>
+
+                    {/* Date filter */}
+                    <div className="w-40">
+                        <Select
+                            name="datePreset"
+                            value={datePreset}
+                            onChange={(value) => setDatePreset(value as '7d' | '30d' | '3m' | '6m' | 'all')}
+                            options={[
+                                { value: '7d', label: 'Last 7 days' },
+                                { value: '30d', label: 'Last 30 days' },
+                                { value: '3m', label: 'Last 3 months' },
+                                { value: '6m', label: 'Last 6 months' },
+                                { value: 'all', label: 'All time' },
+                            ]}
+                            sortOptions={false}
+                        />
+                    </div>
                 </div>
 
                 <IssueList
                     issues={issues.slice(0, 6)}
                     showLocation={false}
-                    emptyStateMessage="No issues found for this park"
+                    emptyStateMessage="No issues found"
                 />
                 
                 {issues.length > 6 && (

--- a/client/src/pages/parks/ParkListPage.tsx
+++ b/client/src/pages/parks/ParkListPage.tsx
@@ -199,7 +199,7 @@ export const ParkListPage: React.FC = () => {
                                                             } 
                                                         }}
                                                         className="font-medium text-blue-600 hover:text-blue-500 truncate">
-                                                        {issue.issueType.charAt(0).toUpperCase() + issue.issueType.slice(1)}
+                                                        {`${issue.issueType.charAt(0).toUpperCase() + issue.issueType.slice(1)  } #${ issue.issueId.toString()}` }
                                                     </Link>
                                                     <div className="ml-4 flex items-center gap-2 whitespace-nowrap">
                                                         <span className={[

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -96,8 +96,32 @@ export const issueApi = {
         return response.issue;
     },
 
-    getIssuesByPark: async (parkId: number): Promise<Issue[]> => {
-        const response = await fetch(`${API_BASE_URL}/issues/park/${parkId}`, {
+    getIssuesByPark: async (
+        parkId: number,
+        statuses?: string[],
+        startDate?: string,
+        endDate?: string
+  	): Promise<Issue[]> => {
+        const params = new URLSearchParams();
+
+        if (statuses !== undefined) {
+            if (statuses.length === 0) {
+                params.append('statuses', 'NONE');
+            } else {
+                statuses.forEach((status) => {
+                    params.append('statuses', status);
+                });
+            }
+        }
+
+        if (startDate) {
+            params.append('startDate', startDate);
+        }
+
+        if (endDate) {
+            params.append('endDate', endDate);
+        }
+        const response = await fetch(`${API_BASE_URL}/issues/park/${parkId}?${params.toString()}`, {
             credentials: 'include'
         })
             .then(handleResponse);

--- a/client/src/utils/issueSafetyRiskUtils.ts
+++ b/client/src/utils/issueSafetyRiskUtils.ts
@@ -4,7 +4,7 @@ export const getSafetyRiskLabel = (level: IssueRiskEnum): string => {
     switch (level) {
     case IssueRiskEnum.NO_RISK: return 'No Risk';
     case IssueRiskEnum.MINOR_RISK: return 'Minor Risk';
-    case IssueRiskEnum.SERIOUS_RISK: return 'Serious Risk / Immediate Danger';
+    case IssueRiskEnum.SERIOUS_RISK: return 'Serious Risk';
     default: return 'No Risk';
     }
 };
@@ -24,19 +24,6 @@ export const getSafetyRiskShortLabel = (level: IssueRiskEnum): string => {
 
 export const getReportedSafetyRiskBadgeLabel = (level: IssueRiskEnum): string => {
     return `Reported ${getSafetyRiskShortLabel(level)}`;
-};
-
-export const getSafetyRiskDescription = (level: IssueRiskEnum): string => {
-    switch (level) {
-    case IssueRiskEnum.NO_RISK:
-        return 'Safe to pass through.';
-    case IssueRiskEnum.MINOR_RISK:
-        return 'Requires caution to avoid injury.';
-    case IssueRiskEnum.SERIOUS_RISK:
-        return 'Dangerous condition, risk of serious harm.';
-    default:
-        return 'Safe to pass through.';
-    }
 };
 
 export const getStewardSafetyRiskDescription = (level: IssueRiskEnum): string => {

--- a/server/src/controllers/IssueController.ts
+++ b/server/src/controllers/IssueController.ts
@@ -3,6 +3,7 @@ import {
 } from '@prisma/client';
 import express from 'express';
 
+import { getIssuesByParkSchema } from '@/schemas/issueSchema';
 import { IssueService, SAME_PARK_ISSUE_GROUP_ERROR } from '@/services/IssueService';
 import { logger } from '@/utils/logger';
 
@@ -69,8 +70,15 @@ export class IssueController {
 
     public async getIssuesByPark(req: express.Request, res: express.Response) {
         try {
-            const parkId = Number(req.params.parkId);
-            const issues = await this.issueService.getIssuesByPark(parkId);
+            const parsed = getIssuesByParkSchema.parse({
+                params: req.params,
+                query: req.query,
+            });
+
+            const { parkId } = parsed.params;
+            const { statuses, startDate, endDate } = parsed.query;
+            const issues = 
+			    await this.issueService.getIssuesByPark(parkId, statuses, startDate, endDate);
             res.json({ issues });
         } catch (error) {
             logger.error(`Error getting issues by park ${req.params.parkId}:`, error);

--- a/server/src/repositories/IssueRepository.ts
+++ b/server/src/repositories/IssueRepository.ts
@@ -201,9 +201,31 @@ export class IssueRepository {
         }
     }
 
-    public async getIssuesByPark(parkId: number): Promise<RepositoryIssue[]> {
+    public async getIssuesByPark(
+        parkId: number, 
+        statuses: IssueStatusEnum[], 
+        startDate?: string, 
+        endDate?: string
+    ): Promise<RepositoryIssue[]> {
         return prisma.issue.findMany({
-            where: { parkId },
+            where: { 
+                parkId, 
+                isPublic: true,
+                ...(statuses.length > 0
+                    ? { status: { in: statuses } }
+                    : { status: { in: [] } }), 
+                ...(startDate || endDate
+                    ? {
+                        createdAt: {
+                            ...(startDate ? { gte: new Date(startDate) } : {}),
+                            ...(endDate ? { lte: new Date(endDate) } : {}),
+                        },
+                    } 
+                    : {}),
+            },
+            orderBy: {
+                createdAt: 'desc'
+            },
             include: this.buildIssueInclude()
         });
     }

--- a/server/src/schemas/issueSchema.ts
+++ b/server/src/schemas/issueSchema.ts
@@ -6,7 +6,21 @@ import { z } from 'zod';
 export const getIssuesByParkSchema = z.object({
     params: z.object({
         parkId: z.coerce.number(),
-    })
+    }),
+    query: z.object({
+        statuses: z
+            .union([
+                z.literal('NONE'),
+                z.nativeEnum(IssueStatusEnum),
+                z.array(z.nativeEnum(IssueStatusEnum)),
+            ])
+            .transform((v) => {
+                if (v === 'NONE') {return [];}
+                return Array.isArray(v) ? v : [v];
+            }),
+        startDate: z.string().optional(),
+        endDate: z.string().optional(),
+    }),
 });
 
 export const getIssuesQuerySchema = z.object({
@@ -37,8 +51,8 @@ export const getIssueMapPinsSchema = z.object({
         bbox: z.string().min(1),
         issueTypes:z
             .union([z.nativeEnum(IssueTypeEnum), z.array(z.nativeEnum(IssueTypeEnum))])
- 		.transform((v) => (v === undefined ? [] : Array.isArray(v) ? v : [v]))
-  		.default([]),
+            .transform((v) => (v === undefined ? [] : Array.isArray(v) ? v : [v]))
+            .default([]),
         statuses: z
             .union([z.nativeEnum(IssueStatusEnum), z.array(z.nativeEnum(IssueStatusEnum))])
             .transform((v) => (

--- a/server/src/services/IssueService.ts
+++ b/server/src/services/IssueService.ts
@@ -165,8 +165,14 @@ export class IssueService {
         return this.issueRepository.deleteIssue(issueId);
     }
 
-    public async getIssuesByPark(parkId: number) {
-        const issues = await this.issueRepository.getIssuesByPark(parkId);
+    public async getIssuesByPark(
+        parkId: number, 
+        statuses: IssueStatusEnum[], 
+        startDate?: string, 
+        endDate?: string
+    ) {
+        const issues = 
+		    await this.issueRepository.getIssuesByPark(parkId, statuses, startDate, endDate);
         return Promise.all(issues.map((issue) => this.toIssueResponse(issue)));
     }
 

--- a/server/test/integration/issueRoutes.test.ts
+++ b/server/test/integration/issueRoutes.test.ts
@@ -132,7 +132,7 @@ describe('Issue API End-to-End', () => {
             issueType: 'WATER' as IssueTypeEnum,
             safetyRisk: 'MINOR_RISK' as IssueRiskEnum,
             reporterEmail: 'sample2@example.com',
-            status: 'OPEN' as IssueStatusEnum,
+            status: 'UNRESOLVED' as IssueStatusEnum,
             notifyReporter: true,
             isPublic: true,
             description: 'Flooding trail again',
@@ -144,6 +144,12 @@ describe('Issue API End-to-End', () => {
             .post('/api/issues')
             .set('Authorization', 'Bearer TEST_TOKEN')
             .send(payload2);
+		expect(sendRes.status).toBe(201);
+        expect(sendRes.body.issue).toMatchObject({
+            parkId: payload2.parkId,
+            issueType: payload2.issueType,
+            reporterEmail: payload2.reporterEmail,
+        });
 
 		const createdIssueId2 = sendRes.body.issue.issueId; 
 		const createdAt2 = sendRes.body.issue.createdAt;
@@ -156,7 +162,7 @@ describe('Issue API End-to-End', () => {
 			.query({
 				bbox,
 				issueTypes: ['OBSTRUCTION', 'WATER'],
-				statuses: ['OPEN', 'IN_PROGRESS']
+				statuses: ['UNRESOLVED', 'IN_PROGRESS']
 			});
 
 		expect(res.status).toBe(200);
@@ -166,7 +172,7 @@ describe('Issue API End-to-End', () => {
 		const pin1 = res.body.pins.find((pin: any) => pin.issueId === createdIssueId);
 		expect(pin1).toBeDefined();
 		expect(pin1.issueType).toBe('OBSTRUCTION');
-		expect(pin1.status).toBe('OPEN');
+		expect(pin1.status).toBe('UNRESOLVED');
 		expect(pin1.latitude).toBe(40.4406);
 		expect(pin1.longitude).toBe(-79.9959);
 		expect(pin1.createdAt).toBe(createdAt);
@@ -174,7 +180,7 @@ describe('Issue API End-to-End', () => {
 		const pin2 = res.body.pins.find((pin: any) => pin.issueId === createdIssueId2);
 		expect(pin2).toBeDefined();
 		expect(pin2.issueType).toBe('WATER');
-		expect(pin2.status).toBe('OPEN');
+		expect(pin2.status).toBe('UNRESOLVED');
 		expect(pin2.latitude).toBe(40.4407);
 		expect(pin2.longitude).toBe(-79.9960);
 		expect(pin2.createdAt).toBe(createdAt2);

--- a/server/test/unit/issueService.test.ts
+++ b/server/test/unit/issueService.test.ts
@@ -194,9 +194,10 @@ describe('IssueService', () => {
         const issues = [baseIssue];
         issueRepositoryMock.getIssuesByPark.mockResolvedValue(issues);
 
-        const result = await issueService.getIssuesByPark(1);
+		const statuses = [IssueStatusEnum.UNRESOLVED, IssueStatusEnum.IN_PROGRESS, IssueStatusEnum.RESOLVED];
+        const result = await issueService.getIssuesByPark(1, statuses);
 
-        expect(issueRepositoryMock.getIssuesByPark).toHaveBeenCalledWith(1);
+        expect(issueRepositoryMock.getIssuesByPark).toHaveBeenCalledWith(1, statuses, undefined, undefined);
         expect(result).toEqual([
             {
                 ...baseIssueWithoutImage,


### PR DESCRIPTION
This PR:
- Fixes UI for the report form 
    - Remove the unnecessary description of the risk
    - Make the upload image box entirely clickable instead of just the Upload text
    - Add a message to inform user that they can edit report after if signed in or opt-in email notif
- Fixes backend
    - Schema for API call for `getIssuesByPark` is modified to accept statuses, and date filter to query only the selected filters
    - Defaulted to 6 months for `UNRESOLVED` and `IN-PROGRESS` issues
    - The options for date are 7 days, 3 months, 6 months, 1 year, All time
- Fixes UI for Dashboard
    - Add status filters
    - Add date range filter
    - Clean up the ParkDetailPage with unnecessary/duplicated info
   

https://github.com/user-attachments/assets/6a5e8923-9487-4f63-bc7a-bcd0b48393a2

